### PR TITLE
fix: correct `exports` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
-    "import": {
+    ".": {
       "default": "./dist/esm/index.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
-    ".": {
-      "default": "./dist/esm/index.js"
-    }
+    ".": "./dist/esm/index.js"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
-    ".": "./dist/esm/index.js"
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.js"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION

Closes https://github.com/eslint/markdown/issues/278

Based on the Node.js docs ([link](https://nodejs.org/api/packages.html#conditional-exports)), I can't say for sure that the existing `exports` field is invalid, but it is certainly uncommon, which might be the issue behind #278. I updated the `exports` field to a more common format as described in the Node.js docs, and based on my testing, it does fix #278.
