### PR TITLE
fix: Remove peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,6 @@
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0"
   },
-  "peerDependencies": {
-    "eslint": ">=9"
-  },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   }


### PR DESCRIPTION
Removes `eslint` as a peer dependency, making it easier to include in the Code Explorer and elsewhere.

Refs https://github.com/eslint/json/pull/25