### PR TITLE
docs: Fix example with individually configured rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export default [
         plugins: {
             markdown
         },
+        language: "markdown/commonmark",
         rules: {
             "markdown/no-html": "error"
         }


### PR DESCRIPTION
Fixes an example in README by adding `language` key, without which the configuration wouldn't work as expected.