### PR TITLE
test: Use latest `typescript-eslint` v8.x

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,6 +7,6 @@
     "@eslint/js": "^9.7.0",
     "eslint": "^9.7.0",
     "typescript": "^5.3.3",
-    "typescript-eslint": "8.0.0-alpha.51"
+    "typescript-eslint": "^8.10.0"
   }
 }


### PR DESCRIPTION
Updates `examples/typescript` test project to use the latest `typescript-eslint` v8.x instead of a prerelease version.