### PR TITLE
chore: mdast-util-from-markdown ^2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@eslint/plugin-kit": "^0.2.0",
-    "mdast-util-from-markdown": "^2.0.1",
+    "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0"
   },


### PR DESCRIPTION
This version of mdast-util-from-markdown upgrades
- micromark to 4.0.0
- unist-util-stringify-position to 4.0.0