### PR TITLE
test: unpin `eslint` in `typescript-eslint` test

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,8 +5,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",
-    "eslint": "9.14.0",
+    "eslint": "^9.15.0",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^8.10.0"
+    "typescript-eslint": "^8.15.0"
   }
 }


### PR DESCRIPTION
Unpins `eslint` in `examples/typescript` since the problem for which it was pinned in https://github.com/eslint/markdown/pull/302 has been resolved in `typescript-eslint` v8.15.0.