### PR TITLE
chore: use eslint-plugin-eslint-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ export default [
 <!-- Rule Table Start -->
 | **Rule Name** | **Description** | **Recommended** |
 | :- | :- | :-: |
-| [`fenced-code-language`](./docs/rules/fenced-code-language.md) | Require languages for fenced code blocks. | yes |
-| [`heading-increment`](./docs/rules/heading-increment.md) | Enforce heading levels increment by one. | yes |
-| [`no-duplicate-headings`](./docs/rules/no-duplicate-headings.md) | Disallow duplicate headings in the same document. | no |
-| [`no-empty-links`](./docs/rules/no-empty-links.md) | Disallow empty links. | yes |
-| [`no-html`](./docs/rules/no-html.md) | Disallow HTML tags. | no |
-| [`no-invalid-label-refs`](./docs/rules/no-invalid-label-refs.md) | Disallow invalid label references. | yes |
-| [`no-missing-label-refs`](./docs/rules/no-missing-label-refs.md) | Disallow missing label references. | yes |
+| [`fenced-code-language`](./docs/rules/fenced-code-language.md) | Require languages for fenced code blocks | yes |
+| [`heading-increment`](./docs/rules/heading-increment.md) | Enforce heading levels increment by one | yes |
+| [`no-duplicate-headings`](./docs/rules/no-duplicate-headings.md) | Disallow duplicate headings in the same document | no |
+| [`no-empty-links`](./docs/rules/no-empty-links.md) | Disallow empty links | yes |
+| [`no-html`](./docs/rules/no-html.md) | Disallow HTML tags | no |
+| [`no-invalid-label-refs`](./docs/rules/no-invalid-label-refs.md) | Disallow invalid label references | yes |
+| [`no-missing-label-refs`](./docs/rules/no-missing-label-refs.md) | Disallow missing label references | yes |
 <!-- Rule Table End -->
 
 **Note:** This plugin does not provide formatting rules. We recommend using a source code formatter such as [Prettier](https://prettier.io) for that purpose.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,24 @@
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
 import globals from "globals";
 import eslintConfigESLint from "eslint-config-eslint";
+import eslintPlugin from "eslint-plugin-eslint-plugin";
 import markdown from "./src/index.js";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const eslintPluginRulesRecommendedConfig =
+	eslintPlugin.configs["flat/rules-recommended"];
+const eslintPluginTestsRecommendedConfig =
+	eslintPlugin.configs["flat/tests-recommended"];
+
+//-----------------------------------------------------------------------------
+// Configuration
+//-----------------------------------------------------------------------------
 
 export default [
 	...eslintConfigESLint,
@@ -71,6 +89,42 @@ export default [
 			"no-alert": "off",
 			"@eslint-community/eslint-comments/require-description": "off",
 			"jsdoc/require-jsdoc": "off",
+		},
+	},
+	{
+		files: ["src/rules/*.js"],
+		...eslintPluginRulesRecommendedConfig,
+		rules: {
+			...eslintPluginRulesRecommendedConfig.rules,
+			"eslint-plugin/require-meta-schema": "off", // `schema` defaults to []
+			"eslint-plugin/prefer-placeholders": "error",
+			"eslint-plugin/prefer-replace-text": "error",
+			"eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
+			"eslint-plugin/require-meta-docs-description": [
+				"error",
+				{ pattern: "^(Enforce|Require|Disallow) .+[^. ]$" },
+			],
+		},
+	},
+	{
+		files: ["tests/rules/*.test.js"],
+		...eslintPluginTestsRecommendedConfig,
+		rules: {
+			...eslintPluginTestsRecommendedConfig.rules,
+			"eslint-plugin/test-case-property-ordering": [
+				"error",
+				[
+					"name",
+					"filename",
+					"code",
+					"output",
+					"language",
+					"options",
+					"languageOptions",
+					"errors",
+				],
+			],
+			"eslint-plugin/test-case-shorthand-strings": "error",
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "dedent": "^1.5.3",
     "eslint": "^9.15.0",
     "eslint-config-eslint": "^11.0.0",
+    "eslint-plugin-eslint-plugin": "^6.3.2",
     "globals": "^15.1.0",
     "got": "^14.4.2",
     "lint-staged": "^15.2.9",

--- a/src/rules/fenced-code-language.js
+++ b/src/rules/fenced-code-language.js
@@ -20,7 +20,7 @@ export default {
 
 		docs: {
 			recommended: true,
-			description: "Require languages for fenced code blocks.",
+			description: "Require languages for fenced code blocks",
 		},
 
 		messages: {

--- a/src/rules/heading-increment.js
+++ b/src/rules/heading-increment.js
@@ -20,7 +20,7 @@ export default {
 
 		docs: {
 			recommended: true,
-			description: "Enforce heading levels increment by one.",
+			description: "Enforce heading levels increment by one",
 		},
 
 		messages: {

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -19,7 +19,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow duplicate headings in the same document.",
+			description: "Disallow duplicate headings in the same document",
 		},
 
 		messages: {

--- a/src/rules/no-empty-links.js
+++ b/src/rules/no-empty-links.js
@@ -19,7 +19,7 @@ export default {
 
 		docs: {
 			recommended: true,
-			description: "Disallow empty links.",
+			description: "Disallow empty links",
 		},
 
 		messages: {

--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -31,7 +31,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow HTML tags.",
+			description: "Disallow HTML tags",
 		},
 
 		messages: {

--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -127,7 +127,7 @@ export default {
 
 		docs: {
 			recommended: true,
-			description: "Disallow invalid label references.",
+			description: "Disallow invalid label references",
 		},
 
 		messages: {

--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -108,7 +108,7 @@ export default {
 
 		docs: {
 			recommended: true,
-			description: "Disallow missing label references.",
+			description: "Disallow missing label references",
 		},
 
 		messages: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enables `eslint-plugin-eslint-plugin` for linting rules and rule tests.

#### What changes did you make? (Give an overview)

Added `eslint-plugin-eslint-plugin` dev dependency and enabled rules in the eslint config.

Also removed the ending dot from `meta.docs.description` in rules.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Config is the same as in eslint/json repo (https://github.com/eslint/json/pull/64).