### PR TITLE
fix: adjust suggestion fix ranges in processor

### DIFF
--- a/tests/processor.test.js
+++ b/tests/processor.test.js
@@ -741,6 +741,16 @@ describe("processor", () => {
 							column: 5,
 							message: "Unexpected console statement.",
 							ruleId: "no-console",
+							suggestions: [
+								{
+									desc: "Replace with 'console.warn'.",
+									messageId: "replace",
+									fix: {
+										range: [45, 56],
+										text: "console.warn",
+									},
+								},
+							],
 						},
 					],
 					[
@@ -874,6 +884,18 @@ describe("processor", () => {
 					const result = processor.postprocess(messagesForBlocks);
 
 					assert.deepStrictEqual(result[0].fix.range, [7, 8]);
+				});
+
+				it("should adjust suggestion fix range properties", () => {
+					const result = processor.postprocess(messages);
+
+					assert.deepStrictEqual(result[1].suggestions, [
+						{
+							desc: "Replace with 'console.warn'.",
+							messageId: "replace",
+							fix: { range: [66, 77], text: "console.warn" },
+						},
+					]);
 				});
 
 				describe("should exclude messages from unsatisfiable rules", () => {


### PR DESCRIPTION
This updates the processor to adjust suggestion fixes in the same way as autofixes.

Currently, with this example config:

```js
// eslint.config.js
import markdown from "@eslint/markdown";

export default [
    {
        files: ["**/*.md"],
        plugins: {
            markdown
        },
        processor: "markdown/markdown"
    },
    {
        files: ["**/*.md/*.js"],
        rules: {
            "require-unicode-regexp": "error"
        }
    }
];
```

and this example code:

![image](https://github.com/user-attachments/assets/75fc0a97-31ae-4aa4-9929-6e267b4c348a)

applying the "Add the 'u' flag" suggestion results in:

![image](https://github.com/user-attachments/assets/5472edbe-ecda-4b14-8d57-7b5ef10f9cf5)

After this change, applying the suggestion will produce the correct result:

![image](https://github.com/user-attachments/assets/b0d04c34-3b1b-4c76-93cc-f8628b15386f)



