### PR TITLE
chore: fix build with pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 package-lock = false
+public-hoist-pattern[] = @types/mdast
+public-hoist-pattern[] = @types/unist


### PR DESCRIPTION
This PR fixes using pnpm as a package manager to install dependencies and build the project.

Without `public-hoist-pattern`,  it would fail at `prepare` script when install dependencies with pnpm.

<details>
<summary>Shell output</summary>

```shell

> @eslint/markdown@6.2.1 prepare /Users/ntnyq/Desktop/github/eslint/markdown
> node ./npm-prepare.cjs && npm run build


> @eslint/markdown@6.2.1 build
> npm run build:rules && rollup -c && npm run build:dedupe-types && tsc -p tsconfig.esm.json && npm run build:update-rules-docs


> @eslint/markdown@6.2.1 build:rules
> node tools/build-rules.js

Recommended rules generated successfully.
Rules import file generated successfully.

src/index.js → dist/esm/index.js...
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
mdast-util-from-markdown (imported by "src/language/markdown-language.js" and "src/processor.js")
mdast-util-gfm (imported by "src/language/markdown-language.js")
micromark-extension-gfm (imported by "src/language/markdown-language.js")
@eslint/plugin-kit (imported by "src/language/markdown-source-code.js")
created dist/esm/index.js in 51ms

> @eslint/markdown@6.2.1 build:dedupe-types
> node tools/dedupe-types.js dist/esm/index.js

dist/esm/index.js:19:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

19 /** @typedef {import("mdast").Node} Node */
                        ~~~~~~~

dist/esm/index.js:20:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

20 /** @typedef {import("mdast").Parent} ParentNode */
                        ~~~~~~~

dist/esm/index.js:21:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

21 /** @typedef {import("mdast").Code} CodeNode */
                        ~~~~~~~

dist/esm/index.js:22:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

22 /** @typedef {import("mdast").Html} HtmlNode */
                        ~~~~~~~

dist/esm/index.js:379:27 - error TS2339: Property 'position' does not exist on type 'Block'.

379  const blockStart = block.position.start.line;
                              ~~~~~~~~

dist/esm/index.js:391:19 - error TS2339: Property 'position' does not exist on type 'Block'.

391     column: block.position.start.column,
                      ~~~~~~~~

dist/esm/index.js:515:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

515 /** @typedef {import("mdast").Root} RootNode */
                         ~~~~~~~

dist/esm/index.js:516:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

516 /** @typedef {import("mdast").Node} MarkdownNode */
                         ~~~~~~~

dist/esm/index.js:517:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

517 /** @typedef {import("mdast").Html} HTMLNode */
                         ~~~~~~~

dist/esm/index.js:1293:22 - error TS2307: Cannot find module 'unist' or its corresponding type declarations.

1293 /** @typedef {import("unist").Position} Position */
                          ~~~~~~~

dist/esm/index.js:1294:22 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

1294 /** @typedef {import("mdast").Text} TextNode */
                          ~~~~~~~

dist/esm/types.ts:1:27 - error TS2307: Cannot find module 'mdast' or its corresponding type declarations.

1 import type { Node } from "mdast";
                            ~~~~~~~


Found 12 errors in 2 files.

Errors  Files
    11  dist/esm/index.js:19
     1  dist/esm/types.ts:1
 ELIFECYCLE  Command failed with exit code 2.
```
</details>
