### PR TITLE
chore: upgrade `@eslint/core` and `@eslint/plugin-kit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "test:types": "tsc -p tests/types/tsconfig.json"
   },
   "devDependencies": {
-    "@eslint/core": "^0.6.0",
     "@eslint/js": "^9.4.0",
     "@types/eslint": "^9.6.0",
     "c8": "^10.1.2",
@@ -81,7 +80,8 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "@eslint/plugin-kit": "^0.2.3",
+    "@eslint/core": "^0.10.0",
+    "@eslint/plugin-kit": "^0.2.5",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0"

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -6,5 +6,6 @@
     "rootDir": "../..",
     "strict": true
   },
-  "files": ["../../dist/esm/index.d.ts", "types.test.ts"]
+  "files": [],
+  "include": [".", "../../dist"]
 }


### PR DESCRIPTION
This PR promotes `@eslint/core` to a runtime dependency and upgrades `@eslint/core` and `@eslint/plugin-kit` to the latest versions.

This change ensures that `@eslint/markdown` will be used with a compatible version of `@eslint/core` in dependent packages even if the core types are changed in a breaking way in the future. This will help avoiding bugs like #313 where the removal of a type from `@eslint/core@0.6.0` to `@eslint/core@0.10.0` was causing the TS build to fail. Since `@eslint/core` was defined in the devDependencies, npm would not check its version range when `@eslint/markdown` was itself installed as a dependency.

I also made a change to the `tsconfig.json` in the type tests because I noticed that some files in the `dist` directory were not being checked.