### PR TITLE
feat: support front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ export default [
 
 #### Enabling Front Matter in both `commonmark` and `gfm`
 
-By default, Markdown parsers do not support [Front Matter](https://jekyllrb.com/docs/front-matter/). To enable Front Matter in both `commonmark` and `gfm`, you can use the `frontmatter` option in `languageOptions`.  
+By default, Markdown parsers do not support [front matter](https://jekyllrb.com/docs/front-matter/). To enable front matter in both `commonmark` and `gfm`, you can use the `frontmatter` option in `languageOptions`.  
 
-> `@eslint/markdown` internally uses [`micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter) and [`mdast-util-frontmatter`](https://github.com/syntax-tree/mdast-util-frontmatter) to parse Front Matter.
+> `@eslint/markdown` internally uses [`micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter) and [`mdast-util-frontmatter`](https://github.com/syntax-tree/mdast-util-frontmatter) to parse front matter.
 
 | **Option Value** | **Description**                                            |
 |------------------|------------------------------------------------------------|
-| `false`          | Disables Front Matter parsing in Markdown files. (Default) |
-| `"yaml"`         | Enables YAML Front Matter parsing in Markdown files.       |
-| `"toml"`         | Enables TOML Front Matter parsing in Markdown files.       |
+| `false`          | Disables front matter parsing in Markdown files. (Default) |
+| `"yaml"`         | Enables YAML front matter parsing in Markdown files.       |
+| `"toml"`         | Enables TOML front matter parsing in Markdown files.       |
 
 ```js
 // eslint.config.js

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ By default, Markdown parsers do not support [Front Matter](https://jekyllrb.com/
 | **Option Value** | **Description**                                            |
 |------------------|------------------------------------------------------------|
 | `false`          | Disables Front Matter parsing in Markdown files. (Default) |
-| `'yaml'`         | Enables YAML Front Matter parsing in Markdown files.       |
-| `'toml'`         | Enables TOML Front Matter parsing in Markdown files.       |
+| `"yaml"`         | Enables YAML Front Matter parsing in Markdown files.       |
+| `"toml"`         | Enables TOML Front Matter parsing in Markdown files.       |
 
 ```js
 // eslint.config.js

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ export default [
 
 By default, Markdown parsers do not support [Front Matter](https://jekyllrb.com/docs/front-matter/). To enable Front Matter in both `commonmark` and `gfm`, you can use the `frontmatter` option in `languageOptions`.  
 
-| **Option Value** | **Description** |  
-|-----------------|-----------------|  
-| `false` | Disables Front Matter parsing in Markdown files. |  
-| `true` | Enables Front Matter parsing in Markdown files. By default, only YAML is supported. |  
-| [`Options`](https://github.com/micromark/micromark-extension-frontmatter?tab=readme-ov-file#options) | Passes configuration options to the Front Matter parser. These options are the same as those in [`Options` from `micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter#options). |
+> `@eslint/markdown` internally uses [`micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter) and [`mdast-util-frontmatter`](https://github.com/syntax-tree/mdast-util-frontmatter) to parse Front Matter.
+
+| **Option Value** | **Description**                                            |
+|------------------|------------------------------------------------------------|
+| `false`          | Disables Front Matter parsing in Markdown files. (Default) |
+| `'yaml'`         | Enables YAML Front Matter parsing in Markdown files.       |
+| `'toml'`         | Enables TOML Front Matter parsing in Markdown files.       |
 
 ```js
 // eslint.config.js
@@ -145,7 +147,7 @@ export default [
         },
         language: "markdown/gfm",
         languageOptions: {
-            frontmatter: true, // Or `["yaml", "toml"]` to enable both YAML and TOML.
+            frontmatter: "yaml", // Or pass `"toml"` to enable TOML Front Matter parsing.
         },
         rules: {
             "markdown/no-html": "error"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ export default [
         },
         language: "markdown/gfm",
         languageOptions: {
-            frontmatter: "yaml", // Or pass `"toml"` to enable TOML Front Matter parsing.
+            frontmatter: "yaml", // Or pass `"toml"` to enable TOML front matter parsing.
         },
         rules: {
             "markdown/no-html": "error"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ export default [
         },
         language: "markdown/gfm",
         languageOptions: {
-            frontmatter: true,
+            frontmatter: true, // Or `["yaml", "toml"]` to enable both YAML and TOML.
         },
         rules: {
             "markdown/no-html": "error"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ export default [
 ];
 ```
 
+### Language Options
+
+#### Enabling Front Matter in both `commonmark` and `gfm`
+
+By default, Markdown parsers do not support [Front Matter](https://jekyllrb.com/docs/front-matter/). To enable Front Matter in both `commonmark` and `gfm`, you can use the `frontmatter` option in `languageOptions`.  
+
+| **Option Value** | **Description** |  
+|-----------------|-----------------|  
+| `false` | Disables Front Matter parsing in Markdown files. |  
+| `true` | Enables Front Matter parsing in Markdown files. By default, only YAML is supported. |  
+| [`Options`](https://github.com/micromark/micromark-extension-frontmatter?tab=readme-ov-file#options) | Passes configuration options to the Front Matter parser. These options are the same as those in [`Options` from `micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter#options). |
+
+```js
+// eslint.config.js
+import markdown from "@eslint/markdown";
+
+export default [
+    {
+        files: ["**/*.md"],
+        plugins: {
+            markdown
+        },
+        language: "markdown/gfm",
+        languageOptions: {
+            frontmatter: true,
+        },
+        rules: {
+            "markdown/no-html": "error"
+        }
+    }
+];
+```
+
 ### Processors
 
 | **Processor Name** | **Description** |

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "@eslint/core": "^0.10.0",
     "@eslint/plugin-kit": "^0.2.5",
     "mdast-util-from-markdown": "^2.0.2",
+    "mdast-util-frontmatter": "^2.0.1",
     "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-frontmatter": "^2.0.0",
     "micromark-extension-gfm": "^3.0.0"
   },
   "engines": {

--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -22,7 +22,7 @@ import { gfm } from "micromark-extension-gfm";
 
 /** @typedef {import("mdast").Root} RootNode */
 /** @typedef {import("mdast-util-from-markdown").Options['extensions']} Extensions */
-/** @typedef {import("mdast-util-from-markdown").Options['mdastExtensions']} mdastExtensions */
+/** @typedef {import("mdast-util-from-markdown").Options['mdastExtensions']} MdastExtensions */
 /** @typedef {import("@eslint/core").Language} Language */
 /** @typedef {import("@eslint/core").File} File */
 /** @typedef {import("@eslint/core").ParseResult<RootNode>} ParseResult */
@@ -39,12 +39,12 @@ import { gfm } from "micromark-extension-gfm";
  * Create parser options based on `mode` and `languageOptions`.
  * @param {ParserMode} mode The markdown parser mode.
  * @param {MarkdownLanguageOptions} languageOptions Language options.
- * @returns {{extensions: Extensions, mdastExtensions: mdastExtensions}} Parser options for micromark and mdast
+ * @returns {{extensions: Extensions, mdastExtensions: MdastExtensions}} Parser options for micromark and mdast
  */
 function createParserOptions(mode, languageOptions) {
 	/** @type {Extensions} */
 	const extensions = [];
-	/** @type {mdastExtensions} */
+	/** @type {MdastExtensions} */
 	const mdastExtensions = [];
 
 	// 1. `mode`: Add GFM extensions if mode is "gfm"

--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -43,13 +43,13 @@ function createParserOptions(mode, languageOptions) {
 	const extensions = [];
 	const mdastExtensions = [];
 
-	// 1. Add GFM extensions if mode is "gfm"
+	// 1. `mode`: Add GFM extensions if mode is "gfm"
 	if (mode === "gfm") {
 		extensions.push(gfm());
 		mdastExtensions.push(gfmFromMarkdown());
 	}
 
-	// 2. Handle frontmatter options
+	// 2. `languageOptions`: Handle frontmatter options
 	const frontmatterOption = languageOptions?.frontmatter;
 
 	// Skip frontmatter entirely if false
@@ -136,17 +136,19 @@ export class MarkdownLanguage {
 	 * @throws {Error} When the language options are invalid.
 	 */
 	validateLanguageOptions(languageOptions) {
-		if (languageOptions.frontmatter !== undefined) {
-			if (typeof languageOptions.frontmatter === "boolean") {
+		const frontmatterOption = languageOptions?.frontmatter;
+
+		if (frontmatterOption !== undefined) {
+			if (typeof frontmatterOption === "boolean") {
 				return;
 			}
 
-			// We know that `languageOptions.frontmatter` is not a boolean here.
+			// We know that `frontmatterOption` is not a boolean here.
 			// If it's not a boolean, it must be `FrontmatterOptions` type.
 
 			// `toMatters` throws an `Error` if the options are invalid.
 			// So, we don't have to implement the validations by ourselves.
-			toMatters(languageOptions.frontmatter);
+			toMatters(frontmatterOption);
 		}
 	}
 

--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -49,7 +49,7 @@ function createParserOptions(mode, languageOptions) {
 		mdastExtensions.push(gfmFromMarkdown());
 	}
 
-	// 2. `languageOptions`: Handle frontmatter options
+	// 2. `languageOptions.frontmatter`: Handle frontmatter options
 	const frontmatterOption = languageOptions?.frontmatter;
 
 	// Skip frontmatter entirely if false

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ import type {
 	Root,
 	Text,
 } from "mdast";
-import type { Options as FrontmatterOptions } from "micromark-extension-frontmatter";
 import type { Linter } from "eslint";
 import type {
 	LanguageOptions,
@@ -65,7 +64,7 @@ export interface MarkdownLanguageOptions extends LanguageOptions {
 	/**
 	 * The options for parsing frontmatter.
 	 */
-	frontmatter?: boolean | FrontmatterOptions;
+	frontmatter?: false | "yaml" | "toml";
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,11 @@ import type {
 	Root,
 	Text,
 } from "mdast";
+import type { Options as FrontmatterOptions } from "micromark-extension-frontmatter";
 import type { Linter } from "eslint";
 import type {
+	LanguageOptions,
+	LanguageContext,
 	RuleDefinition,
 	RuleVisitor,
 	SourceLocation,
@@ -56,11 +59,26 @@ export type Message = Linter.LintMessage;
 export type RuleType = "problem" | "suggestion" | "layout";
 
 /**
+ * Language options provided for Markdown files.
+ */
+export interface MarkdownLanguageOptions extends LanguageOptions {
+	/**
+	 * The options for parsing frontmatter.
+	 */
+	frontmatter?: boolean | FrontmatterOptions;
+}
+
+/**
+ * The context object that is passed to the Markdown language plugin methods.
+ */
+export type MarkdownLanguageContext = LanguageContext<MarkdownLanguageOptions>;
+
+/**
  * The `SourceCode` interface for Markdown files.
  */
 export interface IMarkdownSourceCode
 	extends TextSourceCode<{
-		LangOptions: {};
+		LangOptions: MarkdownLanguageOptions;
 		RootNode: Root;
 		SyntaxElementWithLoc: Node;
 		ConfigNode: { value: string; position: SourceLocation };
@@ -103,7 +121,7 @@ export type MarkdownRuleDefinition<
 > = RuleDefinition<
 	// Language specific type options (non-configurable)
 	{
-		LangOptions: {};
+		LangOptions: MarkdownLanguageOptions;
 		Code: IMarkdownSourceCode;
 		Visitor: MarkdownRuleVisitor;
 		Node: Node;

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -15,6 +15,159 @@ import assert from "node:assert";
 //-----------------------------------------------------------------------------
 
 describe("MarkdownLanguage", () => {
+	describe("validateLanguageOptions()", () => {
+		it("should throw an error if `frontmatter` is not a boolean or `FrontmatterOptions` type", () => {
+			const language = new MarkdownLanguage();
+
+			assert.throws(() => {
+				language.validateLanguageOptions({ frontmatter: "invalid" });
+			}, /Missing matter definition for `invalid`/u);
+			assert.throws(() => {
+				language.validateLanguageOptions({ frontmatter: 123 });
+			}, /Expected matter to be an object, not `123`/u);
+		});
+
+		it("should not throw an error when `frontmatter` is not provided", () => {
+			const language = new MarkdownLanguage();
+
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions();
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({});
+			});
+		});
+
+		it("should not throw an error when `frontmatter` is not provided and other keys are present", () => {
+			const language = new MarkdownLanguage();
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ foo: "bar" });
+			});
+		});
+
+		it("should not throw an error when `frontmatter` is a boolean in commonmark mode", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: true });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: false });
+			});
+		});
+
+		it("should not throw an error when `frontmatter` is a boolean in gfm mode", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: true });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: false });
+			});
+		});
+
+		it("should not throw an error if `frontmatter` is `FrontmatterOptions` type in commonmark mode", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: "yaml" });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: "toml" });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: { type: "yaml", marker: "-" },
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: { type: "toml", marker: "+" },
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: ["yaml"] });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: ["toml"] });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: ["yaml", "toml"],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [{ type: "yaml", marker: "-" }],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [{ type: "toml", marker: "+" }],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [
+						{ type: "yaml", marker: "-" },
+						{ type: "toml", marker: "+" },
+					],
+				});
+			});
+		});
+
+		it("should not throw an error if `frontmatter` is `FrontmatterOptions` type in gfm mode", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: "yaml" });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: "toml" });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: { type: "yaml", marker: "-" },
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: { type: "toml", marker: "+" },
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: ["yaml"] });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: ["toml"] });
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: ["yaml", "toml"],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [{ type: "yaml", marker: "-" }],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [{ type: "toml", marker: "+" }],
+				});
+			});
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({
+					frontmatter: [
+						{ type: "yaml", marker: "-" },
+						{ type: "toml", marker: "+" },
+					],
+				});
+			});
+		});
+	});
+
 	describe("parse()", () => {
 		it("should parse markdown", () => {
 			const language = new MarkdownLanguage();
@@ -68,7 +221,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[3].type, "paragraph");
 		});
 
-		it("should parse frontmatter in commonmark mode when `frontmatter: true` is set", () => {
+		it("should parse YAML frontmatter in commonmark mode when `frontmatter: true` is set", () => {
 			const language = new MarkdownLanguage({ mode: "commonmark" });
 			const result = language.parse(
 				{
@@ -90,7 +243,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[2].type, "paragraph");
 		});
 
-		it("should parse frontmatter in gfm mode when `frontmatter: true` is set", () => {
+		it("should parse YAML frontmatter in gfm mode when `frontmatter: true` is set", () => {
 			const language = new MarkdownLanguage({ mode: "gfm" });
 			const result = language.parse(
 				{
@@ -108,6 +261,50 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.type, "root");
 			assert.strictEqual(result.ast.children[0].type, "yaml");
 			assert.strictEqual(result.ast.children[0].value, "title: Hello");
+			assert.strictEqual(result.ast.children[1].type, "heading");
+			assert.strictEqual(result.ast.children[2].type, "paragraph");
+		});
+
+		it("should parse TOML frontmatter in commonmark mode when `frontmatter: ['toml']` is set", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+			const result = language.parse(
+				{
+					body: "+++\ntitle = 'Hello'\n+++\n\n# Hello, World!\n\nHello, World!",
+					path: "test.md",
+				},
+				{
+					languageOptions: {
+						frontmatter: ["toml"],
+					},
+				},
+			);
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "toml");
+			assert.strictEqual(result.ast.children[0].value, "title = 'Hello'");
+			assert.strictEqual(result.ast.children[1].type, "heading");
+			assert.strictEqual(result.ast.children[2].type, "paragraph");
+		});
+
+		it("should parse TOML frontmatter in gfm mode when `frontmatter: ['toml']` is set", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+			const result = language.parse(
+				{
+					body: "+++\ntitle = 'Hello'\n+++\n\n# Hello, World!\n\nHello, World!",
+					path: "test.md",
+				},
+				{
+					languageOptions: {
+						frontmatter: ["toml"],
+					},
+				},
+			);
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "toml");
+			assert.strictEqual(result.ast.children[0].value, "title = 'Hello'");
 			assert.strictEqual(result.ast.children[1].type, "heading");
 			assert.strictEqual(result.ast.children[2].type, "paragraph");
 		});

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -16,15 +16,15 @@ import assert from "node:assert";
 
 describe("MarkdownLanguage", () => {
 	describe("validateLanguageOptions()", () => {
-		it("should throw an error if `frontmatter` is not a boolean or `FrontmatterOptions` type", () => {
+		it("should throw an error if `frontmatter` is not `false`, `'yaml'`, or `'toml'`", () => {
 			const language = new MarkdownLanguage();
 
 			assert.throws(() => {
 				language.validateLanguageOptions({ frontmatter: "invalid" });
-			}, /Missing matter definition for `invalid`/u);
+			}, /Invalid language option value/u);
 			assert.throws(() => {
 				language.validateLanguageOptions({ frontmatter: 123 });
-			}, /Expected matter to be an object, not `123`/u);
+			}, /Invalid language option value/u);
 		});
 
 		it("should not throw an error when `frontmatter` is not provided", () => {
@@ -45,125 +45,31 @@ describe("MarkdownLanguage", () => {
 			});
 		});
 
-		it("should not throw an error when `frontmatter` is a boolean in commonmark mode", () => {
+		it("should not throw an error when `frontmatter` has a correct value in commonmark mode", () => {
 			const language = new MarkdownLanguage({ mode: "commonmark" });
 
 			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: true });
-			});
-			assert.doesNotThrow(() => {
 				language.validateLanguageOptions({ frontmatter: false });
 			});
-		});
-
-		it("should not throw an error when `frontmatter` is a boolean in gfm mode", () => {
-			const language = new MarkdownLanguage({ mode: "gfm" });
-
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: true });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: false });
-			});
-		});
-
-		it("should not throw an error if `frontmatter` is `FrontmatterOptions` type in commonmark mode", () => {
-			const language = new MarkdownLanguage({ mode: "commonmark" });
-
 			assert.doesNotThrow(() => {
 				language.validateLanguageOptions({ frontmatter: "yaml" });
 			});
 			assert.doesNotThrow(() => {
 				language.validateLanguageOptions({ frontmatter: "toml" });
 			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: { type: "yaml", marker: "-" },
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: { type: "toml", marker: "+" },
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: ["yaml"] });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: ["toml"] });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: ["yaml", "toml"],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [{ type: "yaml", marker: "-" }],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [{ type: "toml", marker: "+" }],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [
-						{ type: "yaml", marker: "-" },
-						{ type: "toml", marker: "+" },
-					],
-				});
-			});
 		});
 
-		it("should not throw an error if `frontmatter` is `FrontmatterOptions` type in gfm mode", () => {
+		it("should not throw an error when `frontmatter` has a correct value in gfm mode", () => {
 			const language = new MarkdownLanguage({ mode: "gfm" });
 
+			assert.doesNotThrow(() => {
+				language.validateLanguageOptions({ frontmatter: false });
+			});
 			assert.doesNotThrow(() => {
 				language.validateLanguageOptions({ frontmatter: "yaml" });
 			});
 			assert.doesNotThrow(() => {
 				language.validateLanguageOptions({ frontmatter: "toml" });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: { type: "yaml", marker: "-" },
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: { type: "toml", marker: "+" },
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: ["yaml"] });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({ frontmatter: ["toml"] });
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: ["yaml", "toml"],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [{ type: "yaml", marker: "-" }],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [{ type: "toml", marker: "+" }],
-				});
-			});
-			assert.doesNotThrow(() => {
-				language.validateLanguageOptions({
-					frontmatter: [
-						{ type: "yaml", marker: "-" },
-						{ type: "toml", marker: "+" },
-					],
-				});
 			});
 		});
 	});
@@ -221,7 +127,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[3].type, "paragraph");
 		});
 
-		it("should parse YAML frontmatter in commonmark mode when `frontmatter: true` is set", () => {
+		it("should parse YAML frontmatter in commonmark mode when `frontmatter: 'yaml'` is set", () => {
 			const language = new MarkdownLanguage({ mode: "commonmark" });
 			const result = language.parse(
 				{
@@ -230,7 +136,7 @@ describe("MarkdownLanguage", () => {
 				},
 				{
 					languageOptions: {
-						frontmatter: true,
+						frontmatter: "yaml",
 					},
 				},
 			);
@@ -243,7 +149,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[2].type, "paragraph");
 		});
 
-		it("should parse YAML frontmatter in gfm mode when `frontmatter: true` is set", () => {
+		it("should parse YAML frontmatter in gfm mode when `frontmatter: 'yaml'` is set", () => {
 			const language = new MarkdownLanguage({ mode: "gfm" });
 			const result = language.parse(
 				{
@@ -252,7 +158,7 @@ describe("MarkdownLanguage", () => {
 				},
 				{
 					languageOptions: {
-						frontmatter: true,
+						frontmatter: "yaml",
 					},
 				},
 			);
@@ -265,7 +171,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[2].type, "paragraph");
 		});
 
-		it("should parse TOML frontmatter in commonmark mode when `frontmatter: ['toml']` is set", () => {
+		it("should parse TOML frontmatter in commonmark mode when `frontmatter: 'toml'` is set", () => {
 			const language = new MarkdownLanguage({ mode: "commonmark" });
 			const result = language.parse(
 				{
@@ -274,7 +180,7 @@ describe("MarkdownLanguage", () => {
 				},
 				{
 					languageOptions: {
-						frontmatter: ["toml"],
+						frontmatter: "toml",
 					},
 				},
 			);
@@ -287,7 +193,7 @@ describe("MarkdownLanguage", () => {
 			assert.strictEqual(result.ast.children[2].type, "paragraph");
 		});
 
-		it("should parse TOML frontmatter in gfm mode when `frontmatter: ['toml']` is set", () => {
+		it("should parse TOML frontmatter in gfm mode when `frontmatter: 'toml'` is set", () => {
 			const language = new MarkdownLanguage({ mode: "gfm" });
 			const result = language.parse(
 				{
@@ -296,7 +202,7 @@ describe("MarkdownLanguage", () => {
 				},
 				{
 					languageOptions: {
-						frontmatter: ["toml"],
+						frontmatter: "toml",
 					},
 				},
 			);

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -52,6 +52,65 @@ describe("MarkdownLanguage", () => {
 			// The table should be parsed correctly.
 			assert.strictEqual(result.ast.children[0].type, "table");
 		});
+
+		it("should not parse frontmatter by default", () => {
+			const language = new MarkdownLanguage();
+			const result = language.parse({
+				body: "---\ntitle: Hello\n---\n\n# Hello, World!\n\nHello, World!",
+				path: "test.md",
+			});
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "thematicBreak");
+			assert.strictEqual(result.ast.children[1].type, "heading");
+			assert.strictEqual(result.ast.children[2].type, "heading");
+			assert.strictEqual(result.ast.children[3].type, "paragraph");
+		});
+
+		it("should parse frontmatter in commonmark mode when `frontmatter: true` is set", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+			const result = language.parse(
+				{
+					body: "---\ntitle: Hello\n---\n\n# Hello, World!\n\nHello, World!",
+					path: "test.md",
+				},
+				{
+					languageOptions: {
+						frontmatter: true,
+					},
+				},
+			);
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "yaml");
+			assert.strictEqual(result.ast.children[0].value, "title: Hello");
+			assert.strictEqual(result.ast.children[1].type, "heading");
+			assert.strictEqual(result.ast.children[2].type, "paragraph");
+		});
+
+		it("should parse frontmatter in gfm mode when `frontmatter: true` is set", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+			const result = language.parse(
+				{
+					body: "---\ntitle: Hello\n---\n\n# Hello, World!\n\nHello, World!",
+					path: "test.md",
+				},
+				{
+					languageOptions: {
+						frontmatter: true,
+					},
+				},
+			);
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "yaml");
+			assert.strictEqual(result.ast.children[0].value, "title: Hello");
+			assert.strictEqual(result.ast.children[1].type, "heading");
+			assert.strictEqual(result.ast.children[2].type, "paragraph");
+		});
 	});
 
 	describe("createSourceCode()", () => {


### PR DESCRIPTION
Hello,  

I've finished adding support for Front Matter.  

The newly added feature is similar to what's described in the newly updated `README.md`.

## Newly Added Feature

### Language Options

#### Enabling Front Matter in both `commonmark` and `gfm`

By default, Markdown parsers do not support [Front Matter](https://jekyllrb.com/docs/front-matter/). To enable Front Matter in both `commonmark` and `gfm`, you can use the `frontmatter` option in `languageOptions`.  

| **Option Value** | **Description** |  
|-----------------|-----------------|  
| `false` | Disables Front Matter parsing in Markdown files. |  
| `true` | Enables Front Matter parsing in Markdown files. By default, only YAML is supported. |  
| [`Options`](https://github.com/micromark/micromark-extension-frontmatter?tab=readme-ov-file#options) | Passes configuration options to the Front Matter parser. These options are the same as those in [`Options` from `micromark-extension-frontmatter`](https://github.com/micromark/micromark-extension-frontmatter#options). |

```js
// eslint.config.js
import markdown from "@eslint/markdown";

export default [
    {
        files: ["**/*.md"],
        plugins: {
            markdown
        },
        language: "markdown/gfm",
        languageOptions: {
            frontmatter: true, // Or `["yaml", "toml"]` to enable both YAML and TOML.
        },
        rules: {
            "markdown/no-html": "error"
        }
    }
];
```

## Newly Added Types  

I've created the `MarkdownLanguageOptions` and `MarkdownLanguageContext` types to support Front Matter.  

A notable addition is the `FrontmatterOptions` type for `languageOptions.frontmatter`, which allows users to extend customizations further. I believe this option will provide more flexibility when parsing Front Matter.

## Prerequisites

- [x] #329

## Resolves

resolve: #325
