### PR TITLE
test: create tests for `MarkdownLanguage`

### DIFF
--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -38,11 +38,7 @@ describe("MarkdownLanguage", () => {
 
 			assert.strictEqual(result.ok, true);
 			// The table should not be parsed and should be recognized as plain text.
-			assert.strictEqual(result.ast.children[0].type === "table", false);
-			assert.strictEqual(
-				result.ast.children[0].type === "paragraph",
-				true,
-			);
+			assert.strictEqual(result.ast.children[0].type, "paragraph");
 		});
 
 		it("should parse gfm features in gfm mode", () => {

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -50,11 +50,7 @@ describe("MarkdownLanguage", () => {
 
 			assert.strictEqual(result.ok, true);
 			// The table should be parsed correctly.
-			assert.strictEqual(result.ast.children[0].type === "table", true);
-			assert.strictEqual(
-				result.ast.children[0].type === "paragraph",
-				false,
-			);
+			assert.strictEqual(result.ast.children[0].type, "table");
 		});
 	});
 

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Tests for MarkdownLanguage
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { MarkdownLanguage } from "../../src/language/markdown-language.js";
+import assert from "node:assert";
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("MarkdownLanguage", () => {
+	describe("parse()", () => {
+		it("should parse markdown", () => {
+			const language = new MarkdownLanguage();
+			const result = language.parse({
+				body: "# Hello, World!\n\nHello, World!",
+				path: "test.css",
+			});
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.ast.type, "root");
+			assert.strictEqual(result.ast.children[0].type, "heading");
+			assert.strictEqual(result.ast.children[1].type, "paragraph");
+		});
+
+		it("should not parse gfm features in commonmark mode", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+			const result = language.parse({
+				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+				path: "test.md",
+			});
+
+			assert.strictEqual(result.ok, true);
+			// The table should not be parsed and should be recognized as plain text.
+			assert.strictEqual(result.ast.children[0].type === "table", false);
+			assert.strictEqual(
+				result.ast.children[0].type === "paragraph",
+				true,
+			);
+		});
+
+		it("should parse gfm features in gfm mode", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+			const result = language.parse({
+				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+				path: "test.md",
+			});
+
+			assert.strictEqual(result.ok, true);
+			// The table should be parsed correctly.
+			assert.strictEqual(result.ast.children[0].type === "table", true);
+			assert.strictEqual(
+				result.ast.children[0].type === "paragraph",
+				false,
+			);
+		});
+	});
+
+	describe("createSourceCode()", () => {
+		it("should create a MarkdownSourceCode instance for commonmark", () => {
+			const language = new MarkdownLanguage({ mode: "commonmark" });
+			const file = {
+				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+				path: "test.json",
+			};
+			const parseResult = language.parse(file);
+			const sourceCode = language.createSourceCode(file, parseResult);
+
+			assert.strictEqual(
+				sourceCode.constructor.name,
+				"MarkdownSourceCode",
+			);
+			assert.strictEqual(sourceCode.ast.type, "root");
+			assert.strictEqual(sourceCode.ast.children[0].type, "paragraph");
+			assert.strictEqual(
+				sourceCode.text,
+				"| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+			);
+		});
+
+		it("should create a MarkdownSourceCode instance for gfm", () => {
+			const language = new MarkdownLanguage({ mode: "gfm" });
+			const file = {
+				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+				path: "test.json",
+			};
+			const parseResult = language.parse(file);
+			const sourceCode = language.createSourceCode(file, parseResult);
+
+			assert.strictEqual(
+				sourceCode.constructor.name,
+				"MarkdownSourceCode",
+			);
+			assert.strictEqual(sourceCode.ast.type, "root");
+			assert.strictEqual(sourceCode.ast.children[0].type, "table");
+			assert.strictEqual(
+				sourceCode.text,
+				"| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
+			);
+		});
+	});
+});


### PR DESCRIPTION
Hello,  

I've created basic test cases for `MarkdownLanguage`. This test was necessary to implement #325 correctly but was missing. I referenced tests for [JSON](https://github.com/eslint/json/blob/main/tests/languages/json-language.test.js) and [CSS](https://github.com/eslint/css/blob/main/tests/languages/css-language.test.js).  

I tried to create a failure case for the `parse()` method, but unlike JSON and CSS parsers, every string value is recognized as text. So, I couldn't make one fail. I'd appreciate it if you could suggest a possible failure case.