### PR TITLE
feat: support `eslint` config comments

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -32,6 +32,7 @@ import { findOffsets } from "../util.js";
 /** @typedef {import("@eslint/core").SourceRange} SourceRange */
 /** @typedef {import("@eslint/core").FileProblem} FileProblem */
 /** @typedef {import("@eslint/core").DirectiveType} DirectiveType */
+/** @typedef {import("@eslint/core").RulesConfig} RulesConfig */
 /** @typedef {import("../types.ts").IMarkdownSourceCode} IMarkdownSourceCode */
 
 //-----------------------------------------------------------------------------
@@ -40,7 +41,7 @@ import { findOffsets } from "../util.js";
 
 const commentParser = new ConfigCommentParser();
 const configCommentStart =
-	/<!--\s*(eslint(?:-enable|-disable(?:(?:-next)?-line)?))(?:\s|-->)/u;
+	/<!--\s*(?:eslint(?:-enable|-disable(?:(?:-next)?-line)?)?)(?:\s|-->)/u;
 const htmlComment = /<!--(.*?)-->/gsu;
 
 /**
@@ -263,6 +264,50 @@ export class MarkdownSourceCode extends TextSourceCodeBase {
 		});
 
 		return { problems, directives };
+	}
+
+	/**
+	 * Returns inline rule configurations along with any problems
+	 * encountered while parsing the configurations.
+	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:SourceLocation}>}} Information
+	 *      that ESLint needs to further process the rule configurations.
+	 */
+	applyInlineConfig() {
+		const problems = [];
+		const configs = [];
+
+		this.getInlineConfigNodes().forEach(comment => {
+			const { label, value } = commentParser.parseDirective(
+				comment.value,
+			);
+
+			if (label === "eslint") {
+				const parseResult = commentParser.parseJSONLikeConfig(value);
+
+				if (parseResult.ok) {
+					configs.push({
+						config: {
+							rules: parseResult.config,
+						},
+						loc: comment.position,
+					});
+				} else {
+					problems.push({
+						ruleId: null,
+						message:
+							/** @type {{ok: false, error: { message: string }}} */ (
+								parseResult
+							).error.message,
+						loc: comment.position,
+					});
+				}
+			}
+		});
+
+		return {
+			configs,
+			problems,
+		};
 	}
 
 	/**

--- a/tests/language/markdown-source-code.test.js
+++ b/tests/language/markdown-source-code.test.js
@@ -45,6 +45,8 @@ eslint-enable no-console -- ok to use console here
 
 <!-- eslint-disable markdown/no-html -- ok here -->
 
+<!-- eslint markdown/no-html: warn, markdown/no-empty-links: error -->
+
 <!-- invalid rule config comments -->
 
 <!-- eslint markdown/no-html: [error -->
@@ -105,7 +107,7 @@ describe("MarkdownSourceCode", () => {
 	describe("getInlineConfigNodes()", () => {
 		it("should return the inline config nodes", () => {
 			const nodes = sourceCode.getInlineConfigNodes();
-			assert.strictEqual(nodes.length, 9);
+			assert.strictEqual(nodes.length, 10);
 
 			/* eslint-disable no-restricted-properties -- Needed to avoid extra asserts. */
 
@@ -166,18 +168,26 @@ describe("MarkdownSourceCode", () => {
 			});
 
 			assert.deepEqual(nodes[7], {
-				value: "eslint markdown/no-html: [error",
+				value: "eslint markdown/no-html: warn, markdown/no-empty-links: error",
 				position: {
-					start: { line: 33, column: 1, offset: 592 },
-					end: { line: 33, column: 41, offset: 632 },
+					start: { line: 31, column: 1, offset: 553 },
+					end: { line: 31, column: 71, offset: 623 },
 				},
 			});
 
 			assert.deepEqual(nodes[8], {
+				value: "eslint markdown/no-html: [error",
+				position: {
+					start: { line: 35, column: 1, offset: 664 },
+					end: { line: 35, column: 41, offset: 704 },
+				},
+			});
+
+			assert.deepEqual(nodes[9], {
 				value: 'eslint markdown/no-html: ["error", { allowed: ["b"] ]',
 				position: {
-					start: { line: 35, column: 1, offset: 634 },
-					end: { line: 35, column: 63, offset: 696 },
+					start: { line: 37, column: 1, offset: 706 },
+					end: { line: 37, column: 63, offset: 768 },
 				},
 			});
 
@@ -242,15 +252,24 @@ describe("MarkdownSourceCode", () => {
 					},
 					loc: allComments[5].position,
 				},
+				{
+					config: {
+						rules: {
+							"markdown/no-html": "warn",
+							"markdown/no-empty-links": "error",
+						},
+					},
+					loc: allComments[7].position,
+				},
 			]);
 
 			assert.strictEqual(problems.length, 2);
 			assert.strictEqual(problems[0].ruleId, null);
 			assert.match(problems[0].message, /Failed to parse/u);
-			assert.strictEqual(problems[0].loc, allComments[7].position);
+			assert.strictEqual(problems[0].loc, allComments[8].position);
 			assert.strictEqual(problems[1].ruleId, null);
 			assert.match(problems[1].message, /Failed to parse/u);
-			assert.strictEqual(problems[1].loc, allComments[8].position);
+			assert.strictEqual(problems[1].loc, allComments[9].position);
 		});
 	});
 
@@ -330,6 +349,16 @@ describe("MarkdownSourceCode", () => {
 					2,
 					"html",
 					"<!-- eslint-disable markdown/no-html -- ok here -->",
+				],
+				[
+					1,
+					"html",
+					"<!-- eslint markdown/no-html: warn, markdown/no-empty-links: error -->",
+				],
+				[
+					2,
+					"html",
+					"<!-- eslint markdown/no-html: warn, markdown/no-empty-links: error -->",
 				],
 				[1, "html", "<!-- invalid rule config comments -->"],
 				[2, "html", "<!-- invalid rule config comments -->"],

--- a/tests/language/markdown-source-code.test.js
+++ b/tests/language/markdown-source-code.test.js
@@ -37,7 +37,19 @@ eslint-enable no-console -- ok to use console here
 
 <!--
  eslint-disable-line no-console
- -->`;
+ -->
+
+<!-- eslint markdown/no-html: "error" -->
+
+<div> This is a div </div>
+
+<!-- eslint-disable markdown/no-html -- ok here -->
+
+<!-- invalid rule config comments -->
+
+<!-- eslint markdown/no-html: [error -->
+
+<!-- eslint markdown/no-html: ["error", { allowed: ["b"] ] -->`;
 
 const ast = fromMarkdown(markdownText);
 
@@ -93,7 +105,7 @@ describe("MarkdownSourceCode", () => {
 	describe("getInlineConfigNodes()", () => {
 		it("should return the inline config nodes", () => {
 			const nodes = sourceCode.getInlineConfigNodes();
-			assert.strictEqual(nodes.length, 5);
+			assert.strictEqual(nodes.length, 9);
 
 			/* eslint-disable no-restricted-properties -- Needed to avoid extra asserts. */
 
@@ -137,6 +149,38 @@ describe("MarkdownSourceCode", () => {
 				},
 			});
 
+			assert.deepEqual(nodes[5], {
+				value: 'eslint markdown/no-html: "error"',
+				position: {
+					start: { line: 25, column: 1, offset: 429 },
+					end: { line: 25, column: 42, offset: 470 },
+				},
+			});
+
+			assert.deepEqual(nodes[6], {
+				value: "eslint-disable markdown/no-html -- ok here",
+				position: {
+					start: { line: 29, column: 1, offset: 500 },
+					end: { line: 29, column: 52, offset: 551 },
+				},
+			});
+
+			assert.deepEqual(nodes[7], {
+				value: "eslint markdown/no-html: [error",
+				position: {
+					start: { line: 33, column: 1, offset: 592 },
+					end: { line: 33, column: 41, offset: 632 },
+				},
+			});
+
+			assert.deepEqual(nodes[8], {
+				value: 'eslint markdown/no-html: ["error", { allowed: ["b"] ]',
+				position: {
+					start: { line: 35, column: 1, offset: 634 },
+					end: { line: 35, column: 63, offset: 696 },
+				},
+			});
+
 			/* eslint-enable no-restricted-properties -- Needed to avoid extra asserts. */
 		});
 	});
@@ -157,7 +201,7 @@ describe("MarkdownSourceCode", () => {
 				end: { line: 23, column: 5, offset: 427 },
 			});
 
-			assert.strictEqual(directives.length, 4);
+			assert.strictEqual(directives.length, 5);
 
 			assert.strictEqual(directives[0].type, "disable-next-line");
 			assert.strictEqual(directives[0].value, "no-console");
@@ -177,6 +221,36 @@ describe("MarkdownSourceCode", () => {
 			assert.strictEqual(directives[3].type, "disable");
 			assert.strictEqual(directives[3].value, "semi");
 			assert.strictEqual(directives[3].justification, "");
+
+			assert.strictEqual(directives[4].type, "disable");
+			assert.strictEqual(directives[4].value, "markdown/no-html");
+			assert.strictEqual(directives[4].justification, "ok here");
+		});
+	});
+
+	describe("applyInlineConfig()", () => {
+		it("should return rule configs and problems", () => {
+			const allComments = sourceCode.getInlineConfigNodes();
+			const { configs, problems } = sourceCode.applyInlineConfig();
+
+			assert.deepStrictEqual(configs, [
+				{
+					config: {
+						rules: {
+							"markdown/no-html": "error",
+						},
+					},
+					loc: allComments[5].position,
+				},
+			]);
+
+			assert.strictEqual(problems.length, 2);
+			assert.strictEqual(problems[0].ruleId, null);
+			assert.match(problems[0].message, /Failed to parse/u);
+			assert.strictEqual(problems[0].loc, allComments[7].position);
+			assert.strictEqual(problems[1].ruleId, null);
+			assert.match(problems[1].message, /Failed to parse/u);
+			assert.strictEqual(problems[1].loc, allComments[8].position);
 		});
 	});
 
@@ -243,6 +317,34 @@ describe("MarkdownSourceCode", () => {
 				],
 				[1, "html", "<!--\n eslint-disable-line no-console\n -->"],
 				[2, "html", "<!--\n eslint-disable-line no-console\n -->"],
+				[1, "html", '<!-- eslint markdown/no-html: "error" -->'],
+				[2, "html", '<!-- eslint markdown/no-html: "error" -->'],
+				[1, "html", "<div> This is a div </div>"],
+				[2, "html", "<div> This is a div </div>"],
+				[
+					1,
+					"html",
+					"<!-- eslint-disable markdown/no-html -- ok here -->",
+				],
+				[
+					2,
+					"html",
+					"<!-- eslint-disable markdown/no-html -- ok here -->",
+				],
+				[1, "html", "<!-- invalid rule config comments -->"],
+				[2, "html", "<!-- invalid rule config comments -->"],
+				[1, "html", "<!-- eslint markdown/no-html: [error -->"],
+				[2, "html", "<!-- eslint markdown/no-html: [error -->"],
+				[
+					1,
+					"html",
+					'<!-- eslint markdown/no-html: ["error", { allowed: ["b"] ] -->',
+				],
+				[
+					2,
+					"html",
+					'<!-- eslint markdown/no-html: ["error", { allowed: ["b"] ] -->',
+				],
 				[2, "root", void 0],
 			]);
 		});


### PR DESCRIPTION
Hello,

I've finished implementing the `applyInlineConfig` method.

For both source code and tests, I referenced [JSON](https://github.com/eslint/json/blob/main/src/languages/json-source-code.js#L208-L250) and [CSS](https://github.com/eslint/css/blob/main/src/languages/css-source-code.js#L208-L250).

I also updated the `configCommentStart` regex to correctly recognize inline configs.

resolves: #330