### PR TITLE
feat: export `MarkdownRuleDefinition` type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,11 @@ import rules from "./build/rules.js";
 /** @typedef {import("eslint").Linter.RulesRecord} RulesRecord*/
 /** @typedef {import("eslint").Linter.Config} Config*/
 /** @typedef {import("eslint").ESLint.Plugin} Plugin */
-/** @typedef {import("./types.ts").MarkdownRuleDefinition} RuleModule */
+/**
+ * @typedef {import("./types.ts").MarkdownRuleDefinition<Options>} MarkdownRuleDefinition<Options>
+ * @template {Partial<import("./types.ts").MarkdownRuleDefinitionTypeOptions>} [Options={}]
+ */
+/** @typedef {MarkdownRuleDefinition} RuleModule */
 /** @typedef {import("./types.ts").MarkdownRuleVisitor} MarkdownRuleVisitor */
 /** @typedef {import("@eslint/core").Language} Language */
 

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,6 +1,7 @@
 import markdown, {
 	IMarkdownSourceCode,
 	MarkdownNode,
+	MarkdownRuleDefinition,
 	MarkdownRuleVisitor,
 	ParentNode,
 	RootNode,
@@ -80,5 +81,82 @@ typeof processorPlugins satisfies {};
 			// Unknown selectors allowed
 			"heading[depth=1]"(node: MarkdownNode, parent?: ParentNode) {},
 		};
+	},
+});
+
+// All options optional - MarkdownRuleDefinition, MarkdownRuleDefinition<{}> and RuleModule
+// should be the same type.
+(
+	rule1: MarkdownRuleDefinition,
+	rule2: MarkdownRuleDefinition<{}>,
+	rule3: RuleModule,
+) => {
+	rule1 satisfies typeof rule2 satisfies typeof rule3;
+	rule2 satisfies typeof rule1 satisfies typeof rule3;
+	rule3 satisfies typeof rule1 satisfies typeof rule2;
+};
+
+// Type restrictions should be enforced
+(): MarkdownRuleDefinition<{
+	RuleOptions: [string, number];
+	MessageIds: "foo" | "bar";
+	ExtRuleDocs: { foo: string; bar: number };
+}> => ({
+	meta: {
+		messages: {
+			foo: "FOO",
+
+			// @ts-expect-error Wrong type for message ID
+			bar: 42,
+		},
+		docs: {
+			foo: "FOO",
+
+			// @ts-expect-error Wrong type for declared property
+			bar: "BAR",
+
+			// @ts-expect-error Wrong type for predefined property
+			description: 42,
+		},
+	},
+	create({ options }) {
+		// Types for rule options
+		options[0] satisfies string;
+		options[1] satisfies number;
+
+		return {};
+	},
+});
+
+// Undeclared properties should produce an error
+(): MarkdownRuleDefinition<{
+	MessageIds: "foo" | "bar";
+	ExtRuleDocs: { foo: number; bar: string };
+}> => ({
+	meta: {
+		messages: {
+			foo: "FOO",
+
+			// Declared message ID is not required
+			// bar: "BAR",
+
+			// @ts-expect-error Undeclared message ID is not allowed
+			baz: "BAZ",
+		},
+		docs: {
+			foo: 42,
+
+			// Declared property is not required
+			// bar: "BAR",
+
+			// @ts-expect-error Undeclared property key is not allowed
+			baz: "BAZ",
+
+			// Predefined property is allowed
+			description: "Lorem ipsum",
+		},
+	},
+	create() {
+		return {};
 	},
 });


### PR DESCRIPTION
This PR exports the type definition for `MarkdownRuleDefinition`, making it accessible to consumers.

refs eslint/eslint#19521