### PR TITLE
docs: create `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+    Thank you for contributing!
+
+    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
+-->
+
+#### Prerequisites checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).
+
+<!--
+    Please ensure your pull request is ready:
+
+    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
+    - Update or create tests
+    - If performance-related, include a benchmark
+    - Update documentation for this change (if appropriate)
+-->
+
+<!--
+    The following is required for all pull requests:
+-->
+
+#### What is the purpose of this pull request?
+
+#### What changes did you make? (Give an overview)
+
+#### Related Issues
+
+<!-- include tags like "fixes #123" or "refs #123" -->
+
+#### Is there anything you'd like reviewers to focus on?
+
+<!-- markdownlint-disable-file MD004 -->


### PR DESCRIPTION
Hello,

I've added a `PULL_REQUEST_TEMPLATE.md` file, as it was previously missing.

I used the template from [eslint/json](https://github.com/eslint/json/blob/main/.github/PULL_REQUEST_TEMPLATE.md) as a reference.