### PR TITLE
chore: add docs url to all rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,13 @@ export default [
 				"error",
 				{ pattern: "^(Enforce|Require|Disallow) .+[^. ]$" },
 			],
+			"eslint-plugin/require-meta-docs-url": [
+				"error",
+				{
+					pattern:
+						"https://github.com/eslint/markdown/blob/main/docs/rules/{{name}}.md",
+				},
+			],
 		},
 	},
 	{

--- a/src/rules/fenced-code-language.js
+++ b/src/rules/fenced-code-language.js
@@ -24,6 +24,7 @@ export default {
 		docs: {
 			recommended: true,
 			description: "Require languages for fenced code blocks",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/fenced-code-language.md",
 		},
 
 		messages: {

--- a/src/rules/heading-increment.js
+++ b/src/rules/heading-increment.js
@@ -24,6 +24,7 @@ export default {
 		docs: {
 			recommended: true,
 			description: "Enforce heading levels increment by one",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/heading-increment.md",
 		},
 
 		messages: {

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -23,6 +23,7 @@ export default {
 
 		docs: {
 			description: "Disallow duplicate headings in the same document",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-duplicate-headings.md",
 		},
 
 		messages: {

--- a/src/rules/no-empty-links.js
+++ b/src/rules/no-empty-links.js
@@ -23,6 +23,7 @@ export default {
 		docs: {
 			recommended: true,
 			description: "Disallow empty links",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-empty-links.md",
 		},
 
 		messages: {

--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -35,6 +35,7 @@ export default {
 
 		docs: {
 			description: "Disallow HTML tags",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-html.md",
 		},
 
 		messages: {

--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -131,6 +131,7 @@ export default {
 		docs: {
 			recommended: true,
 			description: "Disallow invalid label references",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-invalid-label-refs.md",
 		},
 
 		messages: {

--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -112,6 +112,7 @@ export default {
 		docs: {
 			recommended: true,
 			description: "Disallow missing label references",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-missing-label-refs.md",
 		},
 
 		messages: {


### PR DESCRIPTION

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).


#### What is the purpose of this pull request?

to make it easier for consumers to access the documentation

#### What changes did you make? (Give an overview)

enabled [the `eslint-plugin/require-meta-docs-url` rule](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-url.md) and ran the autofixer & autoformatter.

#### Related Issues

-

#### Is there anything you'd like reviewers to focus on?

-
