### PR TITLE
chore: add eslint fix command for Markdown files in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "eslint --fix",
       "prettier --write"
     ],
+    "*.md": "eslint --fix -c eslint.config-content.js",
     "!(*.{js,md})": "prettier --write --ignore-unknown",
     "{src/rules/*.js,tools/update-rules-docs.js,README.md}": "npm run build:update-rules-docs"
   },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

Currently, when I modify Markdown files and try to commit, the pre-commit hooks don't run for them.

As a result, Markdown files often remain unfixed, which usually leads to lint errors in CI.

To address this, I propose adding an `eslint --fix` command for Markdown files in lint-staged.

#### What changes did you make? (Give an overview)

I've added `eslint --fix -c eslint.config-content.js` command for Markdown files in lint-staged.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
