### PR TITLE
chore: bump `@eslint/core` and `@eslint/plugin-kit` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "@eslint/core": "^0.10.0",
-    "@eslint/plugin-kit": "^0.2.5",
+    "@eslint/core": "^0.13.0",
+    "@eslint/plugin-kit": "^0.2.8",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-frontmatter": "^2.0.1",
     "mdast-util-gfm": "^3.0.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

Currently, `@eslint/markdown` relies on somewhat outdated `@eslint` dependencies.

As a result, I’m unable to use newly added features like those introduced in https://github.com/eslint/rewrite/pull/156 and https://github.com/eslint/rewrite/pull/173, since the plugin is still using the `0.x` versions.

Because version `0.10.0` with a caret (`^`) only allows updates up to but not including `0.11.0`, it causes inconsistencies when I try to use the newer types in `@eslint/markdown` and `@eslint/core`.

#### What changes did you make? (Give an overview)

I've updated `@eslint/core` and `@eslint/plugin-kit` to the latest versions!

Technically, updating `@eslint/plugin-kit` wasn't necessary—but I went ahead and bumped it as well for consistency.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
