### PR TITLE
test: correct `path` typos in `markdown-language.test.js`

### DIFF
--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -79,7 +79,7 @@ describe("MarkdownLanguage", () => {
 			const language = new MarkdownLanguage();
 			const result = language.parse({
 				body: "# Hello, World!\n\nHello, World!",
-				path: "test.css",
+				path: "test.md",
 			});
 
 			assert.strictEqual(result.ok, true);
@@ -221,7 +221,7 @@ describe("MarkdownLanguage", () => {
 			const language = new MarkdownLanguage({ mode: "commonmark" });
 			const file = {
 				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
-				path: "test.json",
+				path: "test.md",
 			};
 			const parseResult = language.parse(file);
 			const sourceCode = language.createSourceCode(file, parseResult);
@@ -242,7 +242,7 @@ describe("MarkdownLanguage", () => {
 			const language = new MarkdownLanguage({ mode: "gfm" });
 			const file = {
 				body: "| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |",
-				path: "test.json",
+				path: "test.md",
 			};
 			const parseResult = language.parse(file);
 			const sourceCode = language.createSourceCode(file, parseResult);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

I've corrected `path` typos in `markdown-language.test.js`.

Sorry I missed changing the `path` to `.md` earlier.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
