### PR TITLE
fix: `no-missing-label-refs` rule does not respect escaping

### DIFF
--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -41,7 +41,7 @@ function findMissingReferences(node, nodeText) {
 	 * `right` is the content between the second brackets. It can be empty, and it can be undefined.
 	 */
 	const labelPattern =
-		/(?<!\\)\[(?<left>[^\]]*)(?<!\\)\](?<!\\)(?:\[(?<right>[^\]]*)(?<!\\)\])?/dgu;
+		/(?<!\\)\[(?<left>(?:\\.|[^\]])*)(?<!\\)\](?<!\\)(?:\[(?<right>(?:\\.|[^\]])*)(?<!\\)\])?/dgu;
 
 	let match;
 

--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -40,7 +40,8 @@ function findMissingReferences(node, nodeText) {
 	 * `left` is the content between the first brackets. It can be empty.
 	 * `right` is the content between the second brackets. It can be empty, and it can be undefined.
 	 */
-	const labelPattern = /\[(?<left>[^\]]*)\](?:\[(?<right>[^\]]*)\])?/dgu;
+	const labelPattern =
+		/(?<!\\)\[(?<left>[^\]]*)(?<!\\)\](?<!\\)(?:\[(?<right>[^\]]*)(?<!\\)\])?/dgu;
 
 	let match;
 

--- a/tests/rules/no-missing-label-refs.test.js
+++ b/tests/rules/no-missing-label-refs.test.js
@@ -340,5 +340,18 @@ ruleTester.run("no-missing-label-refs", rule, {
 				},
 			],
 		},
+		{
+			code: "\\[[foo]\\]",
+			errors: [
+				{
+					messageId: "notFound",
+					data: { label: "foo" },
+					line: 1,
+					column: 4,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/no-missing-label-refs.test.js
+++ b/tests/rules/no-missing-label-refs.test.js
@@ -53,6 +53,8 @@ ruleTester.run("no-missing-label-refs", rule, {
 		"\\[escaped\\]\\[escaped\\]",
 		"\\[escaped\\]\\[escaped]",
 		"[escaped\\]\\[escaped\\]",
+		"\\[escaped]\\[escaped]",
+		"[escaped\\][escaped\\]",
 	],
 	invalid: [
 		{
@@ -350,6 +352,32 @@ ruleTester.run("no-missing-label-refs", rule, {
 					column: 4,
 					endLine: 1,
 					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: "[\\[foo\\]]",
+			errors: [
+				{
+					messageId: "notFound",
+					data: { label: "\\[foo\\]" },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 9,
+				},
+			],
+		},
+		{
+			code: "[\\[\\[foo\\]\\]]",
+			errors: [
+				{
+					messageId: "notFound",
+					data: { label: "\\[\\[foo\\]\\]" },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 13,
 				},
 			],
 		},

--- a/tests/rules/no-missing-label-refs.test.js
+++ b/tests/rules/no-missing-label-refs.test.js
@@ -44,6 +44,15 @@ ruleTester.run("no-missing-label-refs", rule, {
 		"foo][bar]\n\n[bar]: http://bar.com",
 		"foo][bar][baz]\n\n[baz]: http://baz.com",
 		"[][foo]\n\n[foo]: http://foo.com",
+		"\\[\\]",
+		"[\\]",
+		"\\[]",
+		"\\[escaped\\]",
+		"\\[escaped]",
+		"[escaped\\]",
+		"\\[escaped\\]\\[escaped\\]",
+		"\\[escaped\\]\\[escaped]",
+		"[escaped\\]\\[escaped\\]",
 	],
 	invalid: [
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello, 

I've fixed https://github.com/eslint/markdown/issues/346.

#### What changes did you make? (Give an overview)

I added negative lookbehind `(?<!\\)` to the regex to properly escape `[` and `]`, and also added some tests.

![image](https://github.com/user-attachments/assets/2a66d17a-6a40-4628-bf0c-7ee423cd4e62)

#### Related Issues

fix: #346

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
