### PR TITLE
chore: replace chai with node.js assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@eslint/js": "^9.4.0",
     "@types/eslint": "^9.6.0",
     "c8": "^10.1.2",
-    "chai": "^5.1.1",
     "dedent": "^1.5.3",
     "eslint": "^9.23.0",
     "eslint-config-eslint": "^11.0.0",

--- a/tests/examples/all.test.js
+++ b/tests/examples/all.test.js
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
 import semver from "semver";
@@ -46,8 +46,8 @@ for (const example of examples) {
 						result => path.basename(result.filePath) == "README.md",
 					);
 
-					assert.isNotNull(readme);
-					assert.isAbove(readme.messages.length, 0);
+					assert.notStrictEqual(readme, null);
+					assert.ok(readme.messages.length > 0);
 				});
 			});
 		});

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -7,7 +7,7 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { assert } from "chai";
+import assert from "node:assert";
 import api from "eslint";
 import unsupportedAPI from "eslint/use-at-your-own-risk";
 import path from "node:path";
@@ -102,7 +102,7 @@ describe("LegacyESLint", () => {
 		it("should include the plugin", async () => {
 			const config = await eslint.calculateConfigForFile("test.md");
 
-			assert.include(config.plugins, "markdown");
+			assert.ok(config.plugins.includes("markdown"));
 		});
 
 		it("applies convenience configuration", async () => {
@@ -214,8 +214,8 @@ describe("LegacyESLint", () => {
 
 			assert.strictEqual(results.length, 1);
 			assert.strictEqual(results[0].messages.length, 1);
-			assert.notProperty(results[0].messages[0], "endLine");
-			assert.notProperty(results[0].messages[0], "endColumn");
+			assert.ok(!Object.hasOwn(results[0].messages[0], "endLine"));
+			assert.ok(!Object.hasOwn(results[0].messages[0], "endColumn"));
 		});
 
 		it("should emit correct line numbers with leading comments", async () => {
@@ -1193,7 +1193,7 @@ describe("FlatESLint", () => {
 		it("should include the plugin", async () => {
 			const config = await eslint.calculateConfigForFile("test.md");
 
-			assert.isDefined(config.plugins.markdown);
+			assert.notStrictEqual(config.plugins.markdown, undefined);
 		});
 
 		it("applies convenience configuration", async () => {
@@ -1304,8 +1304,8 @@ describe("FlatESLint", () => {
 
 			assert.strictEqual(results.length, 1);
 			assert.strictEqual(results[0].messages.length, 1);
-			assert.notProperty(results[0].messages[0], "endLine");
-			assert.notProperty(results[0].messages[0], "endColumn");
+			assert.ok(!Object.hasOwn(results[0].messages[0], "endLine"));
+			assert.ok(!Object.hasOwn(results[0].messages[0], "endColumn"));
 		});
 
 		it("should emit correct line numbers with leading comments", async () => {

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -214,8 +214,8 @@ describe("LegacyESLint", () => {
 
 			assert.strictEqual(results.length, 1);
 			assert.strictEqual(results[0].messages.length, 1);
-			assert.ok(!Object.hasOwn(results[0].messages[0], "endLine"));
-			assert.ok(!Object.hasOwn(results[0].messages[0], "endColumn"));
+			assert.ok(!("endLine" in results[0].messages[0]));
+			assert.ok(!("endColumn" in results[0].messages[0]));
 		});
 
 		it("should emit correct line numbers with leading comments", async () => {
@@ -1304,8 +1304,8 @@ describe("FlatESLint", () => {
 
 			assert.strictEqual(results.length, 1);
 			assert.strictEqual(results[0].messages.length, 1);
-			assert.ok(!Object.hasOwn(results[0].messages[0], "endLine"));
-			assert.ok(!Object.hasOwn(results[0].messages[0], "endColumn"));
+			assert.ok(!("endLine" in results[0].messages[0]));
+			assert.ok(!("endColumn" in results[0].messages[0]));
 		});
 
 		it("should emit correct line numbers with leading comments", async () => {

--- a/tests/processor.test.js
+++ b/tests/processor.test.js
@@ -7,7 +7,7 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { assert } from "chai";
+import assert from "node:assert";
 import path from "node:path";
 import { processor } from "../src/processor.js";
 import fs from "node:fs";
@@ -54,8 +54,10 @@ describe("processor", () => {
 				});
 
 				it("should return an array", () => {
-					assert.isArray(
-						processor.preprocess(`${prefix}Hello, world!`),
+					assert.ok(
+						Array.isArray(
+							processor.preprocess(`${prefix}Hello, world!`),
+						),
 					);
 				});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To reduce the project's dependency footprint by replacing the chai assertion library with node.js built-in assert module. This change maintains the same test coverage and functionality while removing an external dependency.

#### What changes did you make? (Give an overview)

- Replaced chai imports with node.js assert in all test files.
- Updated assertion syntax to use node.js assert equivalents.

#### Related Issues

Fixes #350

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
