### PR TITLE
refactor: switch MarkdownSourceCode to extend TextSourceCodeBase

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "@eslint/core": "^0.14.0",
-    "@eslint/plugin-kit": "^0.3.0",
+    "@eslint/plugin-kit": "^0.3.1",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-frontmatter": "^2.0.1",
     "mdast-util-gfm": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "@eslint/core": "^0.13.0",
-    "@eslint/plugin-kit": "^0.2.8",
+    "@eslint/core": "^0.14.0",
+    "@eslint/plugin-kit": "^0.3.0",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-frontmatter": "^2.0.1",
     "mdast-util-gfm": "^3.0.0",

--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -32,12 +32,7 @@ import { findOffsets } from "../util.js";
 /** @typedef {import("@eslint/core").FileProblem} FileProblem */
 /** @typedef {import("@eslint/core").DirectiveType} DirectiveType */
 /** @typedef {import("@eslint/core").RulesConfig} RulesConfig */
-/**
- * @typedef {import("@eslint/core").TextSourceCode<Options>} TextSourceCode<Options>
- * @template {SourceCodeBaseTypeOptions} [Options=SourceCodeBaseTypeOptions]
- */
 /** @typedef {import("../types.ts").MarkdownLanguageOptions} MarkdownLanguageOptions */
-/** @typedef {import("../types.ts").SourceCodeBaseTypeOptions} SourceCodeBaseTypeOptions */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -141,7 +136,7 @@ function extractInlineConfigCommentsFromHTML(node) {
 
 /**
  * Markdown Source Code Object
- * @implements {TextSourceCode<{LangOptions: MarkdownLanguageOptions, RootNode: RootNode, SyntaxElementWithLoc: MarkdownNode, ConfigNode: { value: string; position: SourceLocation }}>}
+ * @extends {TextSourceCodeBase<{LangOptions: MarkdownLanguageOptions, RootNode: RootNode, SyntaxElementWithLoc: MarkdownNode, ConfigNode: { value: string; position: SourceLocation }}>}
  */
 export class MarkdownSourceCode extends TextSourceCodeBase {
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,16 +116,6 @@ export interface MarkdownLanguageOptions extends LanguageOptions {
  */
 export type MarkdownLanguageContext = LanguageContext<MarkdownLanguageOptions>;
 
-/**
- * Generic options for the `SourceCodeBase` type.
- */
-export interface SourceCodeBaseTypeOptions {
-	LangOptions: LanguageOptions;
-	RootNode: unknown;
-	SyntaxElementWithLoc: unknown;
-	ConfigNode: unknown;
-}
-
 export interface MarkdownRuleVisitor
 	extends RuleVisitor,
 		WithExit<

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -93,7 +93,6 @@ typeof processorPlugins satisfies {};
 			sourceCode.getLoc(node) satisfies SourceLocation;
 			sourceCode.getRange(node) satisfies SourceRange;
 			sourceCode.getParent(node) satisfies Node | undefined;
-			// @ts-expect-error It should be fixed in https://github.com/eslint/markdown/issues/341
 			sourceCode.getAncestors(node) satisfies Node[];
 			sourceCode.getText(node) satisfies string;
 		}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request updates `MarkdownSourceCode` to extend `TextSourceCodeBase`

#### What changes did you make? (Give an overview)

- Upgraded @eslint/core and @eslint/plugin-kit to latest versions
- Switched `MarkdownSourceCode` to extend `TextSourceCodeBase`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
