### PR TITLE
feat: add no-empty-definitions rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ export default defineConfig([
 | [`fenced-code-language`](./docs/rules/fenced-code-language.md) | Require languages for fenced code blocks | yes |
 | [`heading-increment`](./docs/rules/heading-increment.md) | Enforce heading levels increment by one | yes |
 | [`no-duplicate-headings`](./docs/rules/no-duplicate-headings.md) | Disallow duplicate headings in the same document | no |
+| [`no-empty-definitions`](./docs/rules/no-empty-definitions.md) | Disallow empty definitions | yes |
 | [`no-empty-images`](./docs/rules/no-empty-images.md) | Disallow empty images | yes |
 | [`no-empty-links`](./docs/rules/no-empty-links.md) | Disallow empty links | yes |
 | [`no-html`](./docs/rules/no-html.md) | Disallow HTML tags | no |

--- a/docs/rules/no-empty-definitions.md
+++ b/docs/rules/no-empty-definitions.md
@@ -1,0 +1,41 @@
+# no-empty-definitions
+
+Disallow empty definitions.
+
+## Background
+
+Markdown allows you to specify a label as a placeholder for a URL in both links and images using square brackets, such as:
+
+```markdown
+[ESLint][eslint]
+
+[eslint]: https://eslint.org
+```
+
+If the definition's URL is empty or only contains an empty fragment (`#`), then it's not providing any useful information and could be a mistake.
+
+## Rule Details
+
+This rule warns when it finds definitions where the URL is either not specified or contains only an empty fragment (`#`).
+
+Examples of incorrect code:
+
+```markdown
+[earth]: <>
+[earth]: #
+```
+
+Examples of correct code:
+
+```markdown
+[earth]: https://example.com/earth/
+[earth]: #section
+```
+
+## When Not to Use It
+
+If you aren't concerned with empty definitions, you can safely disable this rule.
+
+## Prior Art
+
+* [remark-lint-no-empty-url](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-empty-url)

--- a/src/rules/no-empty-definitions.js
+++ b/src/rules/no-empty-definitions.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Rule to prevent empty definitions in Markdown.
+ * @author Pixel998
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/**
+ * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>}
+ * NoEmptyDefinitionsRuleDefinition
+ */
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {NoEmptyDefinitionsRuleDefinition} */
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			recommended: true,
+			description: "Disallow empty definitions",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-empty-definitions.md",
+		},
+
+		messages: {
+			emptyDefinition: "Unexpected empty definition found.",
+		},
+	},
+
+	create(context) {
+		return {
+			definition(node) {
+				if (!node.url || node.url === "#") {
+					context.report({
+						loc: node.position,
+						messageId: "emptyDefinition",
+					});
+				}
+			},
+		};
+	},
+};

--- a/tests/rules/no-empty-definitions.test.js
+++ b/tests/rules/no-empty-definitions.test.js
@@ -10,6 +10,7 @@
 import rule from "../../src/rules/no-empty-definitions.js";
 import markdown from "../../src/index.js";
 import { RuleTester } from "eslint";
+import dedent from "dedent";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -50,6 +51,28 @@ ruleTester.run("no-empty-definitions", rule, {
 					line: 1,
 					column: 1,
 					endLine: 1,
+					endColumn: 10,
+				},
+			],
+		},
+		{
+			code: dedent`
+			[foo]: #
+			[bar]: <>
+			`,
+			errors: [
+				{
+					messageId: "emptyDefinition",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 9,
+				},
+				{
+					messageId: "emptyDefinition",
+					line: 2,
+					column: 1,
+					endLine: 2,
 					endColumn: 10,
 				},
 			],

--- a/tests/rules/no-empty-definitions.test.js
+++ b/tests/rules/no-empty-definitions.test.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Tests for no-empty-definitions rule.
+ * @author Pixel998
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-empty-definitions.js";
+import markdown from "../../src/index.js";
+import { RuleTester } from "eslint";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		markdown,
+	},
+	language: "markdown/commonmark",
+});
+
+ruleTester.run("no-empty-definitions", rule, {
+	valid: [
+		"[foo]: bar",
+		"[foo]: #bar",
+		"[foo]: http://bar.com",
+		"[foo]: <https://bar.com>",
+	],
+	invalid: [
+		{
+			code: "[foo]: #",
+			errors: [
+				{
+					messageId: "emptyDefinition",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 9,
+				},
+			],
+		},
+		{
+			code: "[foo]: <>",
+			errors: [
+				{
+					messageId: "emptyDefinition",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 10,
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR adds a new rule `no-empty-definitions` to prevent empty URL definitions

#### What changes did you make? (Give an overview)

Added the `no-empty-definitions` rule that warns on empty URLs (<>) or empty fragment URLs (#), along with documentation and tests.

#### Related Issues

Closes #359

<!-- include tags like "fixes #123" or "refs #123" -->

@lumirlumir About including `[foo]:` in the no-empty-definitions rule, I held off because a few weird things popped up when I looked closer.

Take these for example:
```markdown
[foo]:
[bar]:
```
You'd think that's two errors, right? But this actually one definition where foo is the label and the URL is [bar].

So, because of these quirks, I think we should do what remark-lint does and actually check the definition nodes themselves in the code. That way, we're looking at the real definitions and not just the text, which seems much more reliable.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
