### PR TITLE
fix: `no-invalid-label-refs` do not report correct position

### DIFF
--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -15,6 +15,7 @@ import { findOffsets, illegalShorthandTailPattern } from "../util.js";
 
 /** @typedef {import("unist").Position} Position */
 /** @typedef {import("mdast").Text} TextNode */
+/** @typedef {Parameters<import("../types.ts").MarkdownRuleDefinition['create']>[0]['sourceCode']} sourceCode */
 /**
  * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>}
  * NoInvalidLabelRuleDefinition
@@ -30,11 +31,12 @@ const labelPattern = /\]\[([^\]]+)\]/u;
 /**
  * Finds missing references in a node.
  * @param {TextNode} node The node to check.
- * @param {string} nodeText The text of the node.
- * @param {string} docText The text of the document.
+ * @param {sourceCode} sourceCode The Markdown source code object.
  * @returns {Array<{label:string,position:Position}>} The missing references.
  */
-function findInvalidLabelReferences(node, nodeText, docText) {
+function findInvalidLabelReferences(node, sourceCode) {
+	const nodeText = sourceCode.getText(node);
+	const docText = sourceCode.text;
 	const invalid = [];
 	let startIndex = 0;
 	const offset = node.position.start.offset;
@@ -148,8 +150,7 @@ export default {
 			text(node) {
 				const invalidReferences = findInvalidLabelReferences(
 					node,
-					sourceCode.getText(node),
-					sourceCode.text,
+					sourceCode,
 				);
 
 				for (const invalidReference of invalidReferences) {

--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -30,10 +30,11 @@ const labelPattern = /\]\[([^\]]+)\]/u;
 /**
  * Finds missing references in a node.
  * @param {TextNode} node The node to check.
- * @param {string} docText The text of the node.
+ * @param {string} nodeText The text of the node.
+ * @param {string} docText The text of the document.
  * @returns {Array<{label:string,position:Position}>} The missing references.
  */
-function findInvalidLabelReferences(node, docText) {
+function findInvalidLabelReferences(node, nodeText, docText) {
 	const invalid = [];
 	let startIndex = 0;
 	const offset = node.position.start.offset;
@@ -47,8 +48,8 @@ function findInvalidLabelReferences(node, docText) {
 	 * It then moves the start index to the end of the label reference and
 	 * continues searching the text until the end of the text is found.
 	 */
-	while (startIndex < node.value.length) {
-		const value = node.value.slice(startIndex);
+	while (startIndex < nodeText.length) {
+		const value = nodeText.slice(startIndex);
 		const match = value.match(labelPattern);
 
 		if (!match) {
@@ -87,11 +88,11 @@ function findInvalidLabelReferences(node, docText) {
 
 		// find location of [ in the document text
 		const { lineOffset: startLineOffset, columnOffset: startColumnOffset } =
-			findOffsets(node.value, nodeMatchIndex + 1);
+			findOffsets(nodeText, nodeMatchIndex + 1);
 
 		// find location of [ in the document text
 		const { lineOffset: endLineOffset, columnOffset: endColumnOffset } =
-			findOffsets(node.value, nodeMatchIndex + match[0].length);
+			findOffsets(nodeText, nodeMatchIndex + match[0].length);
 
 		const startLine = nodeStartLine + startLineOffset;
 		const startColumn = nodeStartColumn + startColumnOffset;
@@ -147,6 +148,7 @@ export default {
 			text(node) {
 				const invalidReferences = findInvalidLabelReferences(
 					node,
+					sourceCode.getText(node),
 					sourceCode.text,
 				);
 

--- a/tests/rules/no-invalid-label-refs.test.js
+++ b/tests/rules/no-invalid-label-refs.test.js
@@ -127,5 +127,18 @@ ruleTester.run("no-invalid-label-refs", rule, {
 				},
 			],
 		},
+		{
+			code: "eslint [eslint][ ]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "eslint" },
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/no-invalid-label-refs.test.js
+++ b/tests/rules/no-invalid-label-refs.test.js
@@ -140,5 +140,31 @@ ruleTester.run("no-invalid-label-refs", rule, {
 				},
 			],
 		},
+		{
+			code: "\\\\eslint [eslint][ ]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "eslint" },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: "es\\\\lint\\\\ [eslint][ ]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "eslint" },
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

While looking into the `no-invalid-label-refs` rule, I came across an interesting bug.

For example, in the code below, the rule correctly reports the position of the `[ ]`:

![image](https://github.com/user-attachments/assets/79e6f5a6-c999-4c39-9e92-4282fb74ea8f)

However, what happens if I insert a `\\` into the sentence?

![image](https://github.com/user-attachments/assets/3cf0e48b-909f-4dcc-9196-2d5867b68907)

The error line shifts forward by one line every time I add a `\\`:

![image](https://github.com/user-attachments/assets/2db3e061-6344-41ca-a129-2c5d041c3426)

#### What changes did you make? (Give an overview)

The cause of this bug is that when using `node.value`, the `\\` is interpreted as a single `\`. As a result, the reported position changes whenever I insert a `\\`.

To fix this, I replaced `node.value` with `context.sourceCode.getText(node)` so that the position can be accurately tracked.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
