### PR TITLE
feat: add require-alt-text rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ export default defineConfig([
 | [`no-empty-links`](./docs/rules/no-empty-links.md) | Disallow empty links | yes |
 | [`no-html`](./docs/rules/no-html.md) | Disallow HTML tags | no |
 | [`no-invalid-label-refs`](./docs/rules/no-invalid-label-refs.md) | Disallow invalid label references | yes |
-| [`no-missing-alt-text`](./docs/rules/no-missing-alt-text.md) | Disallow images without an alternative text | yes |
 | [`no-missing-label-refs`](./docs/rules/no-missing-label-refs.md) | Disallow missing label references | yes |
+| [`require-alt-text`](./docs/rules/require-alt-text.md) | Require alternative text for images | yes |
 <!-- Rule Table End -->
 
 **Note:** This plugin does not provide formatting rules. We recommend using a source code formatter such as [Prettier](https://prettier.io) for that purpose.

--- a/docs/rules/require-alt-text.md
+++ b/docs/rules/require-alt-text.md
@@ -1,6 +1,6 @@
-# no-missing-alt-text
+# require-alt-text
 
-Disallow images without an alternative text.
+Require alternative text for images.
 
 ## Background
 
@@ -10,7 +10,7 @@ Providing alternative text for images is essential for accessibility. Without al
 
 This rule warns when it finds images that either don't have alternative text or have only whitespace as alternative text.
 
-The rule does not warn when:
+This rule does not warn when:
 - An HTML image has an empty alt attribute (`alt=""`)
 - An HTML image has the `aria-hidden="true"` attribute
 

--- a/src/rules/require-alt-text.js
+++ b/src/rules/require-alt-text.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to prevent images without an alternative text in Markdown.
+ * @fileoverview Rule to require alternative text for images in Markdown.
  * @author Pixel998
  */
 
@@ -15,7 +15,7 @@ import { findOffsets } from "../util.js";
 
 /**
  * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>}
- * NoMissingAltTextRuleDefinition
+ * RequireAltTextRuleDefinition
  */
 
 //-----------------------------------------------------------------------------
@@ -37,19 +37,19 @@ function getHtmlAttributeRe(name) {
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoMissingAltTextRuleDefinition} */
+/** @type {RequireAltTextRuleDefinition} */
 export default {
 	meta: {
 		type: "problem",
 
 		docs: {
 			recommended: true,
-			description: "Disallow images without an alternative text",
-			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-missing-alt-text.md",
+			description: "Require alternative text for images",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/require-alt-text.md",
 		},
 
 		messages: {
-			missingAltText: "Missing alternative text for image.",
+			altTextRequired: "Alternative text for image is required.",
 		},
 	},
 
@@ -59,7 +59,7 @@ export default {
 				if (node.alt.trim().length === 0) {
 					context.report({
 						loc: node.position,
-						messageId: "missingAltText",
+						messageId: "altTextRequired",
 					});
 				}
 			},
@@ -68,7 +68,7 @@ export default {
 				if (node.alt.trim().length === 0) {
 					context.report({
 						loc: node.position,
-						messageId: "missingAltText",
+						messageId: "altTextRequired",
 					});
 				}
 			},
@@ -131,7 +131,7 @@ export default {
 									column: endColumn,
 								},
 							},
-							messageId: "missingAltText",
+							messageId: "altTextRequired",
 						});
 					}
 				}

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Tests for no-missing-alt-text rule.
+ * @fileoverview Tests for require-alt-text rule.
  * @author Pixel998
  */
 
@@ -7,7 +7,7 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import rule from "../../src/rules/no-missing-alt-text.js";
+import rule from "../../src/rules/require-alt-text.js";
 import markdown from "../../src/index.js";
 import { RuleTester } from "eslint";
 import dedent from "dedent";
@@ -23,7 +23,7 @@ const ruleTester = new RuleTester({
 	language: "markdown/commonmark",
 });
 
-ruleTester.run("no-missing-alt-text", rule, {
+ruleTester.run("require-alt-text", rule, {
 	valid: [
 		"![Alternative text](image.jpg)",
 		'![Alternative text](image.jpg "Title")',
@@ -50,7 +50,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: "![ ](image.jpg)",
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -62,7 +62,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: "![](image.jpg)",
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -74,7 +74,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: '![](image.jpg "Title")',
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -86,7 +86,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: "Image without an alternative text ![](image.jpg) in a sentence.",
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 35,
 					endLine: 1,
@@ -101,7 +101,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			[notitle]: image.jpg`,
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -116,7 +116,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			[title]: image.jpg "Title"`,
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -128,7 +128,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: "[![](image.jpg)](image.jpg)",
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 2,
 					endLine: 1,
@@ -140,7 +140,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: '<img src="image.png" />',
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -152,7 +152,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: '<IMG SRC="image.png" />',
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -164,7 +164,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: '<img src="image.png" alt=" " />',
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -180,7 +180,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			`,
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -197,14 +197,14 @@ ruleTester.run("no-missing-alt-text", rule, {
 			`,
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 2,
 					column: 1,
 					endLine: 2,
 					endColumn: 24,
 				},
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -216,7 +216,7 @@ ruleTester.run("no-missing-alt-text", rule, {
 			code: '<img src="image.png" aria-hidden="false"/>',
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -231,7 +231,7 @@ ruleTester.run("no-missing-alt-text", rule, {
   			`,
 			errors: [
 				{
-					messageId: "missingAltText",
+					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 2,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR adds a new rule require-alt-text to prevent images without alternate text

#### What changes did you make? (Give an overview)

Added the require-alt-text rule, along with documentation and tests.

#### Related Issues

Closes #365

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
