### PR TITLE
feat: add no-missing-space-atx rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ export default defineConfig([
 | [`no-html`](./docs/rules/no-html.md) | Disallow HTML tags | no |
 | [`no-invalid-label-refs`](./docs/rules/no-invalid-label-refs.md) | Disallow invalid label references | yes |
 | [`no-missing-label-refs`](./docs/rules/no-missing-label-refs.md) | Disallow missing label references | yes |
+| [`no-missing-space-atx`](./docs/rules/no-missing-space-atx.md) | Disallow headings without a space after the hash characters | yes |
 <!-- Rule Table End -->
 
 **Note:** This plugin does not provide formatting rules. We recommend using a source code formatter such as [Prettier](https://prettier.io) for that purpose.

--- a/docs/rules/no-missing-space-atx.md
+++ b/docs/rules/no-missing-space-atx.md
@@ -1,0 +1,46 @@
+# no-missing-space-atx
+
+This rule warns when spaces are missing after the hash characters in an ATX style heading.
+
+## Rule Details
+
+In Markdown, headings can be created using ATX style (using hash characters at the beginning of the line) or Setext style (using underlining with equals or hyphens).
+
+For ATX style headings, a space should be used after the hash characters to improve readability and ensure proper rendering across various Markdown parsers.
+
+This rule is automatically fixable by the `--fix` command line option.
+
+Examples of **incorrect** code for this rule:
+
+```md
+#Heading 1
+##Heading 2
+###Heading 3
+```
+
+Examples of **correct** code for this rule:
+
+```md
+# Heading 1
+## Heading 2
+### Heading 3
+```
+
+Lines that contain hash characters but are not headings (not at the beginning of the line) will not be flagged:
+
+```md
+This is a paragraph with a #hashtag, not a heading.
+```
+
+## When Not To Use It
+
+You might want to turn this rule off if you're working with a Markdown variant that doesn't require spaces after hash characters in headings.
+
+## Prior Art
+
+[MD018 - No space after hash on atx style heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md)
+
+## Further Reading
+
+- [Markdown Syntax: Headings](https://daringfireball.net/projects/markdown/syntax#header)
+- [CommonMark Spec: ATX Headings](https://spec.commonmark.org/0.30/#atx-headings) 

--- a/tests/rules/no-missing-space-atx.test.js
+++ b/tests/rules/no-missing-space-atx.test.js
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Tests for no-missing-space-atx rule.
+ * @author Sweta Tanwar
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-missing-space-atx.js";
+import markdown from "../../src/index.js";
+import { RuleTester } from "eslint";
+import dedent from "dedent";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		markdown,
+	},
+	language: "markdown/commonmark",
+});
+
+// Construct test scenarios
+const validHeadings = [
+	// Valid ATX headings with proper space
+	"# Heading 1",
+	"## Heading 2",
+	"### Heading 3",
+	"#### Heading 4",
+	"##### Heading 5",
+	"###### Heading 6",
+
+	// Multiple headings with proper spacing
+	dedent`# Heading 1
+
+	## Heading 2
+	
+	### Heading 3`,
+
+	// Extra space is fine
+	"#  Heading with extra space",
+];
+
+const nonHeadings = [
+	// Just hashes (not headings)
+	"#",
+	"##",
+
+	// Setext headings (not covered by rule)
+	"Heading 1\n=========",
+	"Heading 2\n---------",
+
+	// Not headings
+	"Not a heading",
+	"This is a paragraph with a #hashtag",
+];
+
+const codeBlocks = [
+	// Code blocks
+	'```js\n#Not a heading in a code block\nconsole.log("#Not a heading");\n```',
+
+	// Lines with code markers should be skipped
+	dedent`Text before
+	#Heading with \`\`\` code markers - should be skipped
+	Text after`,
+
+	// Lines with tilde markers should be skipped
+	dedent`Text before
+	#Heading with ~~~ tilde markers - should be skipped
+	Text after`,
+
+	// Text node with code markers (to test the early return condition)
+	"#Something with ``` backticks",
+
+	// Another variation with code markers
+	"#Heading with ``` in the middle and more text after",
+
+	// Text with tilde markers
+	"#Title with ~~~ tildes in it",
+];
+
+const edgeTestCases = [
+	// Test node with backticks as the entire content (to test line 93)
+	"```",
+
+	// Text with code markers at start (to better test hasCodeBlockMarkers early return)
+	"``` followed by text",
+
+	// Text with tilde markers at start
+	"~~~ followed by more text",
+];
+
+/**
+ * Creates an invalid test case for a specific heading level
+ * @param {number} level The heading level (1-6)
+ * @returns {Object} The test case object
+ */
+function createInvalidTest(level) {
+	const hashes = "#".repeat(level);
+	return {
+		code: `${hashes}Heading ${level}`,
+		output: `${hashes} Heading ${level}`,
+		errors: [{ messageId: "missingSpace", column: level }],
+	};
+}
+
+// Create array of invalid test cases
+const invalidTests = [
+	// Basic heading tests (levels 1-6)
+	...Array.from({ length: 6 }, (_, i) => createInvalidTest(i + 1)),
+
+	// Mixed valid and invalid heading in document
+	{
+		code: dedent`# Heading 1
+
+		##Heading 2
+		
+		### Heading 3`,
+		output: dedent`# Heading 1
+
+		## Heading 2
+		
+		### Heading 3`,
+		errors: [
+			{
+				messageId: "missingSpace",
+				line: 3,
+				column: 2,
+			},
+		],
+	},
+
+	// Special cases
+	{
+		code: "#Heading with trailing space ",
+		output: "# Heading with trailing space ",
+		errors: [{ messageId: "missingSpace", column: 1 }],
+	},
+	{
+		code: "#Text",
+		output: "# Text",
+		errors: [{ messageId: "missingSpace", column: 1 }],
+	},
+];
+
+ruleTester.run("no-missing-space-atx", rule, {
+	valid: [...validHeadings, ...nonHeadings, ...codeBlocks, ...edgeTestCases],
+	invalid: invalidTests,
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
This PR adds a new rule `no-missing-space-atx` to ensure there is a space after hash on ATX style headings in Markdown


#### What changes did you make? (Give an overview)
Added the `no-missing-space-atx` rule, along with documentation and tests.


#### Related Issues
fixes #370 

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
