### PR TITLE
docs: imporve documentation with inline config comments

### DIFF
--- a/docs/rules/require-alt-text.md
+++ b/docs/rules/require-alt-text.md
@@ -14,9 +14,11 @@ This rule does not warn when:
 - An HTML image has an empty alt attribute (`alt=""`)
 - An HTML image has the `aria-hidden="true"` attribute
 
-Examples of incorrect code:
+Examples of **incorrect** code:
 
 ```markdown
+<!-- eslint markdown/require-alt-text: "error" -->
+
 ![](sunset.png)
 
 ![ ](sunset.png)
@@ -30,9 +32,11 @@ Examples of incorrect code:
 <img src="sunset.png" alt=" ">
 ```
 
-Examples of correct code:
+Examples of **correct** code:
 
 ```markdown
+<!-- eslint markdown/require-alt-text: "error" -->
+
 ![A beautiful sunset](sunset.png)
 
 ![Company logo][logo]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

The other rules had correctly configured inline config comments in their documentation; however, the `require-alt-text` rule had not, so I've added them.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
