### PR TITLE
fix: update `require-alt-text` rule to ignore commented images

### DIFF
--- a/src/rules/require-alt-text.js
+++ b/src/rules/require-alt-text.js
@@ -22,7 +22,7 @@ import { findOffsets } from "../util.js";
 // Helpers
 //-----------------------------------------------------------------------------
 
-const imgTagPattern = /<img[^>]*>/giu;
+const imgTagPattern = /(?<!<!--[\s\S]*?)<img[^>]*>/giu;
 
 /**
  * Creates a regex to match HTML attributes

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -44,6 +44,7 @@ ruleTester.run("require-alt-text", rule, {
 		'<img src="image.png" aria-hidden="true"/>',
 		'<img src="image.png" ARIA-HIDDEN="TRUE" />',
 		'<p><img src="image.png" alt="Descriptive text" /></p>',
+		'<!-- <img src="image.png" /> -->',
 	],
 	invalid: [
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I've updated the `require-alt-text` rule to ignore commented-out images.

Currently, when I write a markdown document like the one below, it shows a false positive:

```md
<!-- <img src="image.png" /> -->
```

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
