### PR TITLE
feat: added new rule table-column-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ export default defineConfig([
 | [`no-missing-atx-heading-space`](./docs/rules/no-missing-atx-heading-space.md) | Disallow headings without a space after the hash characters | yes |
 | [`no-missing-label-refs`](./docs/rules/no-missing-label-refs.md) | Disallow missing label references | yes |
 | [`require-alt-text`](./docs/rules/require-alt-text.md) | Require alternative text for images | yes |
+| [`table-column-count`](./docs/rules/table-column-count.md) | Disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row | yes |
 <!-- Rule Table End -->
 
 **Note:** This plugin does not provide formatting rules. We recommend using a source code formatter such as [Prettier](https://prettier.io) for that purpose.

--- a/docs/rules/table-column-count.md
+++ b/docs/rules/table-column-count.md
@@ -4,7 +4,7 @@ Disallow data rows in a GitHub Flavored Markdown table from having more cells th
 
 ## Background
 
-In GitHub Flavored Markdown [tables](https://github.github.com/gfm/#tables-extension-), rows should maintain a consistent number of cells. While variations are sometimes tolerated, data rows having *more* cells than the header can lead to lost data or rendering issues. This rule focuses on preventing data rows from exceeding the header's column count.
+In GitHub Flavored Markdown [tables](https://github.github.com/gfm/#tables-extension-), rows should maintain a consistent number of cells. While variations are sometimes tolerated, data rows having *more* cells than the header can lead to lost data or rendering issues. This rule prevents data rows from exceeding the header's column count.
 
 ## Rule Details
 
@@ -14,7 +14,7 @@ In GitHub Flavored Markdown [tables](https://github.github.com/gfm/#tables-exten
 
 This rule is triggered if a data row in a GFM table contains more cells than the header row. It does not flag rows with fewer cells than the header.
 
-Examples of **incorrect** code for this rule (i.e., will be flagged):
+Examples of **incorrect** code for this rule:
 
 ```markdown
 <!-- eslint markdown/table-column-count: "error" -->
@@ -28,7 +28,7 @@ Examples of **incorrect** code for this rule (i.e., will be flagged):
 | 1 | 2 | <!-- This data row has 2 cells, header has 1 -->
 ```
 
-Examples of **correct** code for this rule (i.e., will NOT be flagged):
+Examples of **correct** code for this rule:
 
 ```markdown
 <!-- eslint markdown/table-column-count: "error" -->
@@ -48,7 +48,7 @@ Examples of **correct** code for this rule (i.e., will NOT be flagged):
 | Col A | Col B | Col C |
 | ----- | ----- | ----- |
 | 1     |       | 3     |
-| 4     | 5     |       |
+| 4     | 5     |
 
 <!-- Single column table -->
 | Single Header |
@@ -58,8 +58,8 @@ Examples of **correct** code for this rule (i.e., will NOT be flagged):
 
 ## When Not To Use It
 
-If you are intentionally creating Markdown tables where data rows are expected to contain more cells than the header, and you have a specific (perhaps non-standard) processing or rendering pipeline that handles this scenario correctly, you might choose to disable this rule. However, for typical GFM rendering and data consistency, adhering to this rule is recommended.
+If you intentionally create Markdown tables where data rows are expected to contain more cells than the header, and you have a specific (perhaps non-standard) processing or rendering pipeline that handles this scenario correctly, you might choose to disable this rule. However, adhering to this rule is recommended for typical GFM rendering and data consistency.
 
 ## Prior Art
 
-* [table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md056---table-column-count)
+* [MD056 - table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md056---table-column-count)

--- a/docs/rules/table-column-count.md
+++ b/docs/rules/table-column-count.md
@@ -1,0 +1,65 @@
+# table-column-count
+
+Disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row.
+
+## Background
+
+In GitHub Flavored Markdown [tables](https://github.github.com/gfm/#tables-extension-), rows should maintain a consistent number of cells. While variations are sometimes tolerated, data rows having *more* cells than the header can lead to lost data or rendering issues. This rule focuses on preventing data rows from exceeding the header's column count.
+
+## Rule Details
+
+> [!IMPORTANT] <!-- eslint-disable-line -- This should be fixed in https://github.com/eslint/markdown/issues/294 -->
+>
+> This rule relies on the `table` AST node, typically available when using a GFM-compatible parser (e.g., `language: "markdown/gfm"`).
+
+This rule is triggered if a data row in a GFM table contains more cells than the header row. It does not flag rows with fewer cells than the header.
+
+Examples of **incorrect** code for this rule (i.e., will be flagged):
+
+```markdown
+<!-- eslint markdown/table-column-count: "error" -->
+
+| Head1 | Head2 |
+| ----- | ----- |
+| R1C1  | R1C2  | R2C3  | <!-- This data row has 3 cells, header has 2 -->
+
+| A |
+| - |
+| 1 | 2 | <!-- This data row has 2 cells, header has 1 -->
+```
+
+Examples of **correct** code for this rule (i.e., will NOT be flagged):
+
+```markdown
+<!-- eslint markdown/table-column-count: "error" -->
+
+<!-- Standard correct table -->
+| Header | Header |
+| ------ | ------ |
+| Cell   | Cell   |
+| Cell   | Cell   |
+
+<!-- Data row with fewer cells than header (VALID for this rule) -->
+| Header | Header | Header |
+| ------ | ------ | ------ |
+| Cell   | Cell   |        |
+
+<!-- Table with some empty cells (VALID for this rule) -->
+| Col A | Col B | Col C |
+| ----- | ----- | ----- |
+| 1     |       | 3     |
+| 4     | 5     |       |
+
+<!-- Single column table -->
+| Single Header |
+| ------------- |
+| Single Cell   |
+```
+
+## When Not To Use It
+
+If you are intentionally creating Markdown tables where data rows are expected to contain more cells than the header, and you have a specific (perhaps non-standard) processing or rendering pipeline that handles this scenario correctly, you might choose to disable this rule. However, for typical GFM rendering and data consistency, adhering to this rule is recommended.
+
+## Prior Art
+
+* [table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md056---table-column-count)

--- a/docs/rules/table-column-count.md
+++ b/docs/rules/table-column-count.md
@@ -40,11 +40,13 @@ Examples of **correct** code for this rule:
 | Cell   | Cell   |
 
 <!-- Data row with fewer cells than header (VALID for this rule) -->
+<!-- Rows with fewer cells are valid because they render correctly and no data is lost -->
 | Header | Header | Header |
 | ------ | ------ | ------ |
 | Cell   | Cell   |        |
 
 <!-- Table with some empty cells (VALID for this rule) -->
+<!-- Missing cells are treated as empty and don't cause rendering issues -->
 | Col A | Col B | Col C |
 | ----- | ----- | ----- |
 | 1     |       | 3     |

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -51,19 +51,13 @@ export default {
 						const firstExtraCellNode =
 							currentRow.children[expectedCellsLength];
 
+						const lastActualCellNode =
+							currentRow.children[actualCellsLength - 1];
+
 						context.report({
-							node: currentRow,
 							loc: {
-								start: {
-									line: firstExtraCellNode.position.start
-										.line,
-									column: firstExtraCellNode.position.start
-										.column,
-								},
-								end: {
-									line: currentRow.position.end.line,
-									column: currentRow.position.end.column,
-								},
+								start: firstExtraCellNode.position.start,
+								end: lastActualCellNode.position.end,
 							},
 							messageId: "inconsistentColumnCount",
 							data: {

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -29,7 +29,7 @@ export default {
 
 		messages: {
 			inconsistentColumnCount:
-				"Data row {{dataRowIndex}} (1-indexed) has {{actualCells}} cells, but header has {{expectedCells}} cells (should not exceed header count).",
+				"Table column count mismatch (Expected: {{expectedCells}}, Actual: {{actualCells}}), extra data will be ignored.",
 		},
 	},
 
@@ -52,7 +52,6 @@ export default {
 							node: currentRow,
 							messageId: "inconsistentColumnCount",
 							data: {
-								dataRowIndex: String(i),
 								actualCells: String(actualCells),
 								expectedCells: String(expectedCells),
 							},

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -36,20 +36,20 @@ export default {
 	create(context) {
 		return {
 			table(node) {
-				if (!node.children || node.children.length < 1) {
+				if (node.children.length < 1) {
 					return;
 				}
 
 				const headerRow = node.children[0];
-				const expectedCells = headerRow.children.length;
+				const expectedCellsLength = headerRow.children.length;
 
 				for (let i = 1; i < node.children.length; i++) {
 					const currentRow = node.children[i];
-					const actualCells = currentRow.children.length;
+					const actualCellsLength = currentRow.children.length;
 
-					if (actualCells > expectedCells) {
+					if (actualCellsLength > expectedCellsLength) {
 						const firstExtraCellNode =
-							currentRow.children[expectedCells];
+							currentRow.children[expectedCellsLength];
 
 						context.report({
 							node: currentRow,
@@ -67,8 +67,8 @@ export default {
 							},
 							messageId: "inconsistentColumnCount",
 							data: {
-								actualCells: String(actualCells),
-								expectedCells: String(expectedCells),
+								actualCells: String(actualCellsLength),
+								expectedCells: String(expectedCellsLength),
 							},
 						});
 					}

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Rule to ensure GitHub Flavored Markdown tables have a consistent number of cells in each row.
+ * @author Sweta Tanwar (@SwetaTanwar)
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/**
+ * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>} TableColumnCountRuleDefinition
+ */
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {TableColumnCountRuleDefinition} */
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			recommended: true,
+			description:
+				"Disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/table-column-count.md",
+		},
+
+		fixable: null,
+		schema: [],
+
+		messages: {
+			inconsistentColumnCount:
+				"Data row {{dataRowIndex}} (1-indexed) has {{actualCells}} cells, but header has {{expectedCells}} cells (should not exceed header count).",
+		},
+	},
+
+	create(context) {
+		return {
+			table(node) {
+				if (!node.children || node.children.length < 1) {
+					return;
+				}
+
+				const headerRow = node.children[0];
+				const expectedCells = headerRow.children.length;
+
+				for (let i = 1; i < node.children.length; i++) {
+					const currentRow = node.children[i];
+					const actualCells = currentRow.children.length;
+
+					if (actualCells > expectedCells) {
+						context.report({
+							node: currentRow,
+							messageId: "inconsistentColumnCount",
+							data: {
+								dataRowIndex: String(i),
+								actualCells: String(actualCells),
+								expectedCells: String(expectedCells),
+							},
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -29,7 +29,7 @@ export default {
 
 		messages: {
 			inconsistentColumnCount:
-				"Table column count mismatch (Expected: {{expectedCells}}, Actual: {{actualCells}}), extra data will be ignored.",
+				"Table column count mismatch (Expected: {{expectedCells}}, Actual: {{actualCells}}), extra data starting here will be ignored.",
 		},
 	},
 
@@ -48,8 +48,23 @@ export default {
 					const actualCells = currentRow.children.length;
 
 					if (actualCells > expectedCells) {
+						const firstExtraCellNode =
+							currentRow.children[expectedCells];
+
 						context.report({
 							node: currentRow,
+							loc: {
+								start: {
+									line: firstExtraCellNode.position.start
+										.line,
+									column: firstExtraCellNode.position.start
+										.column,
+								},
+								end: {
+									line: currentRow.position.end.line,
+									column: currentRow.position.end.column,
+								},
+							},
 							messageId: "inconsistentColumnCount",
 							data: {
 								actualCells: String(actualCells),

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to ensure GitHub Flavored Markdown tables have a consistent number of cells in each row.
+ * @fileoverview Rule to disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row
  * @author Sweta Tanwar (@SwetaTanwar)
  */
 
@@ -26,9 +26,6 @@ export default {
 				"Disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row",
 			url: "https://github.com/eslint/markdown/blob/main/docs/rules/table-column-count.md",
 		},
-
-		fixable: null,
-		schema: [],
 
 		messages: {
 			inconsistentColumnCount:

--- a/tests/rules/table-column-count.test.js
+++ b/tests/rules/table-column-count.test.js
@@ -67,6 +67,27 @@ ruleTester.run("table-column-count", rule, {
             | ----- | ----- |
             | Row   | Here  |
         `,
+		dedent`
+			| abc | defghi |
+			:-: | -----------:
+			bar | baz
+		`,
+		dedent`
+            | f|oo  |
+            | ------ |
+            | b \`|\` az |
+            | b **|** im |
+        `,
+		dedent`
+			| abc | def |
+			| --- | --- |
+			| bar | baz |
+			> bar
+		`,
+		dedent`
+			| abc | def |
+			| --- | --- |
+		`,
 	],
 
 	invalid: [
@@ -84,6 +105,23 @@ ruleTester.run("table-column-count", rule, {
 					column: 17,
 					endLine: 3,
 					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: dedent`
+                | Head1 | Head2 |
+                | ----- | ----- |
+                | R1C1  | R1C2  | R2C3  | R3C4 |
+            `,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "4", expectedCells: "2" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 33,
 				},
 			],
 		},
@@ -123,6 +161,42 @@ ruleTester.run("table-column-count", rule, {
 					column: 21,
 					endLine: 5,
 					endColumn: 30,
+				},
+			],
+		},
+		{
+			code: dedent`
+                | abc | defghi |
+				:-: | -----------:
+				bar | baz
+				bar | baz | bad
+            `,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 4,
+					column: 11,
+					endLine: 4,
+					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: dedent`
+					| abc | def |
+					| --- | --- |
+					| bar | baz | Extra |
+					> This is a blockquote after
+				`,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 3,
+					column: 13,
+					endLine: 3,
+					endColumn: 22,
 				},
 			],
 		},

--- a/tests/rules/table-column-count.test.js
+++ b/tests/rules/table-column-count.test.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Tests for table-column-count rule.
+ * @author Sweta Tanwar (@SwetaTanwar)
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/table-column-count.js";
+import markdown from "../../src/index.js";
+import { RuleTester } from "eslint";
+import dedent from "dedent";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		markdown,
+	},
+	language: "markdown/gfm",
+});
+
+ruleTester.run("table-column-count", rule, {
+	valid: [
+		dedent`
+            | Header | Header |
+            | ------ | ------ |
+            | Cell   | Cell   |
+            | Cell   | Cell   |
+        `,
+		dedent`
+            | Header | Header | Header |
+            | ------ | ------ | ------ |
+            | Cell   | Cell   |
+            | Cell   |        |
+        `,
+		dedent`
+            | A | B |
+            |---|---|
+            |   |   |
+            | C |   |
+        `,
+		`Just some text. | not a table |`,
+		dedent`
+            | Header | Header |
+            | ------ | ------ | ----- |
+            | Cell   | Cell   |
+        `,
+		dedent`
+            | Header | Header |
+            | ------ | ------ |
+        `,
+		dedent`
+            Some text before.
+
+            | H1 | H2 |
+            |----|----|
+            | D1 | D2 |
+
+            Some text after.
+        `,
+		dedent`
+            | Valid | Table |
+            | ----- | ----- |
+            | Row   | Here  |
+        `,
+	],
+
+	invalid: [
+		{
+			code: dedent`
+                | Head1 | Head2 |
+                | ----- | ----- |
+                | R1C1  | R1C2  | R2C3  |
+            `,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: {
+						dataRowIndex: "1",
+						actualCells: "3",
+						expectedCells: "2",
+					},
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: dedent`
+                | A |
+                | - |
+                | 1 | 2 |
+            `,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: {
+						dataRowIndex: "1",
+						actualCells: "2",
+						expectedCells: "1",
+					},
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 10,
+				},
+			],
+		},
+		{
+			code: dedent`
+                Some introductory text.
+
+                | Header1 | Header2 |
+                | ------- | ------- |
+                | Data1   | Data2   | Data3 |
+                | D4      | D5      |
+
+                Some concluding text.
+            `,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: {
+						dataRowIndex: "1",
+						actualCells: "3",
+						expectedCells: "2",
+					},
+					line: 5,
+					column: 1,
+					endLine: 5,
+					endColumn: 30,
+				},
+			],
+		},
+	],
+});

--- a/tests/rules/table-column-count.test.js
+++ b/tests/rules/table-column-count.test.js
@@ -200,5 +200,58 @@ ruleTester.run("table-column-count", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`
+				| abc | def |
+				| --- | --- |
+				| bar | baz | Extra1 |
+				| bar | baz | Extra2 |
+			`,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 3,
+					column: 13,
+					endLine: 3,
+					endColumn: 23,
+				},
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 4,
+					column: 13,
+					endLine: 4,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: dedent`
+			| abc | def |
+			| --- | --- |
+			| bar | baz | Extra1 |
+		    | bar | baz |
+			| bar | baz | Extra2 |
+		`,
+			errors: [
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 3,
+					column: 13,
+					endLine: 3,
+					endColumn: 23,
+				},
+				{
+					messageId: "inconsistentColumnCount",
+					data: { actualCells: "3", expectedCells: "2" },
+					line: 5,
+					column: 13,
+					endLine: 5,
+					endColumn: 23,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/table-column-count.test.js
+++ b/tests/rules/table-column-count.test.js
@@ -79,13 +79,9 @@ ruleTester.run("table-column-count", rule, {
 			errors: [
 				{
 					messageId: "inconsistentColumnCount",
-					data: {
-						dataRowIndex: "1",
-						actualCells: "3",
-						expectedCells: "2",
-					},
+					data: { actualCells: "3", expectedCells: "2" },
 					line: 3,
-					column: 1,
+					column: 17,
 					endLine: 3,
 					endColumn: 26,
 				},
@@ -100,13 +96,9 @@ ruleTester.run("table-column-count", rule, {
 			errors: [
 				{
 					messageId: "inconsistentColumnCount",
-					data: {
-						dataRowIndex: "1",
-						actualCells: "2",
-						expectedCells: "1",
-					},
+					data: { actualCells: "2", expectedCells: "1" },
 					line: 3,
-					column: 1,
+					column: 5,
 					endLine: 3,
 					endColumn: 10,
 				},
@@ -126,13 +118,9 @@ ruleTester.run("table-column-count", rule, {
 			errors: [
 				{
 					messageId: "inconsistentColumnCount",
-					data: {
-						dataRowIndex: "1",
-						actualCells: "3",
-						expectedCells: "2",
-					},
+					data: { actualCells: "3", expectedCells: "2" },
 					line: 5,
-					column: 1,
+					column: 21,
 					endLine: 5,
 					endColumn: 30,
 				},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
This PR adds a new rule `table-column-count` to disallow data rows in a [GitHub Flavored Markdown table](https://github.github.com/gfm/#tables-extension-) from having more cells than the header row


#### What changes did you make? (Give an overview)
Added the `table-column-count` rule, along with documentation and tests.


#### Related Issues
fixes #389 

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
