### PR TITLE
feat: add checkSiblingsOnly option to no-duplicate-headings rule

### DIFF
--- a/docs/rules/no-duplicate-headings.md
+++ b/docs/rules/no-duplicate-headings.md
@@ -30,6 +30,32 @@ Goodbye World!
 # Goodbye World!
 ```
 
+## Options
+
+The following options are available on this rule:
+
+* `siblingsOnly: boolean` - When set to `true`, the rule will only check for duplicate headings among headings that share the same immediate parent heading. Default is `false`.
+
+Examples of **correct** code for this rule with `siblingsOnly: true`:
+
+```markdown
+<!-- eslint markdown/no-duplicate-headings: ["error", { "siblingsOnly": true }] -->
+
+# Change log
+
+## 1.0.0
+
+### Features
+### Bug Fixes
+
+## 2.0.0
+
+### Features
+### Bug Fixes
+```
+
+In this example, the duplicate "Features" and "Bug Fixes" headings are allowed because they have different parent headings ("1.0.0" vs "2.0.0").
+
 ## When Not to Use It
 
 If you aren't concerned with autolinking heading or autogenerating a table of contents, you can safely disable this rule.

--- a/docs/rules/no-duplicate-headings.md
+++ b/docs/rules/no-duplicate-headings.md
@@ -34,12 +34,12 @@ Goodbye World!
 
 The following options are available on this rule:
 
-* `siblingsOnly: boolean` - When set to `true`, the rule will only check for duplicate headings among headings that share the same immediate parent heading. Default is `false`.
+* `checkSiblingsOnly: boolean` - When set to `true`, the rule will only check for duplicate headings among headings that share the same immediate parent heading. Default is `false`.
 
-Examples of **correct** code for this rule with `siblingsOnly: true`:
+Examples of **correct** code for this rule with `checkSiblingsOnly: true`:
 
 ```markdown
-<!-- eslint markdown/no-duplicate-headings: ["error", { "siblingsOnly": true }] -->
+<!-- eslint markdown/no-duplicate-headings: ["error", { "checkSiblingsOnly": true }] -->
 
 # Change log
 

--- a/docs/rules/no-duplicate-headings.md
+++ b/docs/rules/no-duplicate-headings.md
@@ -39,7 +39,7 @@ The following options are available on this rule:
 Examples of **correct** code for this rule with `checkSiblingsOnly: true`:
 
 ```markdown
-<!-- eslint markdown/no-duplicate-headings: ["error", { "checkSiblingsOnly": true }] -->
+<!-- eslint markdown/no-duplicate-headings: ["error", { checkSiblingsOnly: true }] -->
 
 # Change log
 

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -7,8 +7,9 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
+/** @typedef {import("mdast").Heading} HeadingNode */
 /**
- * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>}
+ * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: [{ siblingsOnly?: boolean; }]; }>}
  * NoDuplicateHeadingsRuleDefinition
  */
 
@@ -29,46 +30,88 @@ export default {
 		messages: {
 			duplicateHeading: 'Duplicate heading "{{text}}" found.',
 		},
+
+		schema: [
+			{
+				type: "object",
+				properties: {
+					siblingsOnly: {
+						type: "boolean",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+
+		defaultOptions: [{ siblingsOnly: false }],
 	},
 
 	create(context) {
-		const headings = new Set();
+		const [{ siblingsOnly }] = context.options;
 		const { sourceCode } = context;
+
+		const headingsByLevel = [null, []];
+		let lastLevel = 1;
+		let currentLevelHeadings = headingsByLevel[lastLevel];
+
+		/**
+		 * Gets the text of a heading node
+		 * @param {HeadingNode} node The heading node
+		 * @returns {string} The heading text
+		 */
+		function getHeadingText(node) {
+			/*
+			 * There are two types of headings in markdown:
+			 * - ATX headings, which start with one or more # characters
+			 * - Setext headings, which are underlined with = or -
+			 * Setext headings are identified by being on two lines instead of one,
+			 * with the second line containing only = or - characters. In order to
+			 * get the correct heading text, we need to determine which type of
+			 * heading we're dealing with.
+			 */
+			const isSetext =
+				node.position.start.line !== node.position.end.line;
+
+			return isSetext
+				? // get only the text from the first line
+					sourceCode.lines[node.position.start.line - 1].trim()
+				: // get the text without the leading # characters
+					sourceCode
+						.getText(node)
+						.slice(node.depth + 1)
+						.trim();
+		}
 
 		return {
 			heading(node) {
-				/*
-				 * There are two types of headings in markdown:
-				 * - ATX headings, which start with one or more # characters
-				 * - Setext headings, which are underlined with = or -
-				 * Setext headings are identified by being on two lines instead of one,
-				 * with the second line containing only = or - characters. In order to
-				 * get the correct heading text, we need to determine which type of
-				 * heading we're dealing with.
-				 */
-				const isSetext =
-					node.position.start.line !== node.position.end.line;
+				const headingText = getHeadingText(node);
 
-				const text = isSetext
-					? // get only the text from the first line
-						sourceCode.lines[node.position.start.line - 1].trim()
-					: // get the text without the leading # characters
-						sourceCode
-							.getText(node)
-							.slice(node.depth + 1)
-							.trim();
+				if (siblingsOnly) {
+					const currentLevel = node.depth;
+					while (lastLevel < currentLevel) {
+						lastLevel++;
+						headingsByLevel[lastLevel] = [];
+					}
 
-				if (headings.has(text)) {
+					while (lastLevel > currentLevel) {
+						headingsByLevel[lastLevel] = [];
+						lastLevel--;
+					}
+
+					currentLevelHeadings = headingsByLevel[currentLevel];
+				}
+
+				if (currentLevelHeadings.includes(headingText)) {
 					context.report({
 						loc: node.position,
 						messageId: "duplicateHeading",
 						data: {
-							text,
+							text: headingText,
 						},
 					});
+				} else {
+					currentLevelHeadings.push(headingText);
 				}
-
-				headings.add(text);
 			},
 		};
 	},

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -40,7 +40,7 @@ ruleTester.run("no-duplicate-headings", rule, {
 
 				### Features
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 		},
 		{
 			code: dedent`
@@ -56,7 +56,7 @@ ruleTester.run("no-duplicate-headings", rule, {
 				Features
 				--------
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 		},
 		{
 			code: dedent`
@@ -71,7 +71,7 @@ ruleTester.run("no-duplicate-headings", rule, {
 
 				## Features
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 		},
 	],
 	invalid: [
@@ -147,7 +147,7 @@ Heading 1
 
 				# Heading 1
             `,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",
@@ -169,7 +169,7 @@ Heading 1
 
 				## Subsection B
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",
@@ -192,7 +192,7 @@ Heading 1
 				## Subsection A
 				## Subsection A
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",
@@ -219,7 +219,7 @@ Heading 1
 				Subsection B
 				------------
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",
@@ -248,7 +248,7 @@ Heading 1
 				Subsection A
 				------------
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",
@@ -273,7 +273,7 @@ Heading 1
 				Subsection A
 				------------
 			`,
-			options: [{ siblingsOnly: true }],
+			options: [{ checkSiblingsOnly: true }],
 			errors: [
 				{
 					messageId: "duplicateHeading",

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -28,6 +28,11 @@ ruleTester.run("no-duplicate-headings", rule, {
 		`# Heading 1
 
         ## Heading 2`,
+		dedent`
+			# Heading 1
+
+			# Heading 1#
+		`,
 		{
 			code: dedent`
 				# Change log
@@ -39,6 +44,20 @@ ruleTester.run("no-duplicate-headings", rule, {
 				## 2.0.0
 
 				### Features
+			`,
+			options: [{ checkSiblingsOnly: true }],
+		},
+		{
+			code: dedent`
+				# Change log
+
+				## 1.0.0
+
+				### Features
+
+				## 2.0.0
+
+				### Features ###
 			`,
 			options: [{ checkSiblingsOnly: true }],
 		},
@@ -88,6 +107,38 @@ ruleTester.run("no-duplicate-headings", rule, {
 					column: 1,
 					endLine: 4,
 					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Heading 1
+			
+				# Heading 1 ##
+            `,
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 15,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Heading 1
+				
+				# Heading 1 ##########
+            `,
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 23,
 				},
 			],
 		},
@@ -177,6 +228,28 @@ Heading 1
 					column: 1,
 					endLine: 4,
 					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Section 1
+
+				## Subsection A
+				## Subsection A ###
+
+				# Section 2
+
+				## Subsection B
+			`,
+			options: [{ checkSiblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 4,
+					column: 1,
+					endLine: 4,
+					endColumn: 20,
 				},
 			],
 		},

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -10,6 +10,7 @@
 import rule from "../../src/rules/no-duplicate-headings.js";
 import markdown from "../../src/index.js";
 import { RuleTester } from "eslint";
+import dedent from "dedent";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -27,6 +28,51 @@ ruleTester.run("no-duplicate-headings", rule, {
 		`# Heading 1
 
         ## Heading 2`,
+		{
+			code: dedent`
+				# Change log
+
+				## 1.0.0
+
+				### Features
+
+				## 2.0.0
+
+				### Features
+			`,
+			options: [{ siblingsOnly: true }],
+		},
+		{
+			code: dedent`
+				1.0.0
+				=====
+
+				Features
+				--------
+
+				2.0.0
+				=====
+
+				Features
+				--------
+			`,
+			options: [{ siblingsOnly: true }],
+		},
+		{
+			code: dedent`
+				1.0.0
+				=====
+
+				Features
+				--------
+
+				2.0.0
+				=====
+
+				## Features
+			`,
+			options: [{ siblingsOnly: true }],
+		},
 	],
 	invalid: [
 		{
@@ -92,6 +138,156 @@ Heading 1
 					column: 1,
 					endLine: 5,
 					endColumn: 10,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Heading 1
+
+				# Heading 1
+            `,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Section 1
+
+				## Subsection A
+				## Subsection A
+
+				# Section 2
+
+				## Subsection B
+			`,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 4,
+					column: 1,
+					endLine: 4,
+					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Section 1
+
+				## Subsection A
+				## Subsection B
+
+				# Section 2
+
+				## Subsection A
+				## Subsection A
+			`,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 9,
+					column: 1,
+					endLine: 9,
+					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: dedent`
+				Section 1
+				=========
+
+				Subsection A
+				------------
+				Subsection A
+				------------
+
+				Section 2
+				=========
+
+				Subsection B
+				------------
+			`,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 6,
+					column: 1,
+					endLine: 7,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`
+				Section 1
+				=========
+
+				Subsection A
+				------------
+				Subsection B
+				------------
+
+				Section 2
+				=========
+
+				Subsection A
+				------------
+				Subsection A
+				------------
+			`,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 14,
+					column: 1,
+					endLine: 15,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`
+				# Section 1
+
+				## Subsection A
+				## Subsection B
+
+				# Section 2
+
+				## Subsection A
+				## Subsection A
+				Subsection A
+				------------
+			`,
+			options: [{ siblingsOnly: true }],
+			errors: [
+				{
+					messageId: "duplicateHeading",
+					line: 9,
+					column: 1,
+					endLine: 9,
+					endColumn: 16,
+				},
+				{
+					messageId: "duplicateHeading",
+					line: 10,
+					column: 1,
+					endLine: 11,
+					endColumn: 13,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR adds a new siblingsOnly option to the no-duplicate-headings rule to make it more flexible. Currently, the rule flags any duplicate headings in the entire document, which can be too restrictive in some cases. With this new option, users can configure the rule to only check for duplicate headings among siblings (headings at the same level under the same parent heading).

#### What changes did you make? (Give an overview)

Added a new siblingsOnly boolean option to the rule's schema and refactored the implementation to track headings by level, resetting tracking when moving between levels when siblingsOnly is enabled. Updated documentation and added test cases for both ATX and setext-style headings to verify the new behavior.

#### Related Issues

Fixes #390

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
