### PR TITLE
fix: Cast plugin as ESLint.Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/eslint": "^9.6.0",
     "c8": "^10.1.2",
     "dedent": "^1.5.3",
-    "eslint": "^9.25.1",
+    "eslint": "^9.28.0",
     "eslint-config-eslint": "^11.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.2",
     "globals": "^15.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ const processorRulesConfig = {
 
 let recommendedPlugins, processorPlugins;
 
+/** @type {Plugin} */
 const plugin = {
 	meta: {
 		name: "@eslint/markdown",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To fix the generated types of the plugin exported from `index.js`.

#### What changes did you make? (Give an overview)

- Cast the export as `ESLint.Plugin`
- Updated ESLint

#### Related Issues

Fixes https://github.com/eslint/markdown/issues/402

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
