### PR TITLE
chore: remove `@types/eslint` and bump mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@eslint/js": "^9.4.0",
     "c8": "^10.1.2",
     "dedent": "^1.5.3",
-    "eslint": "^9.25.1",
+    "eslint": "^9.28.0",
     "eslint-config-eslint": "^11.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.2",
     "globals": "^15.1.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've removed `@types/eslint` and bumped the version of `mocha`.

As far as I know, `eslint` now includes types based on `@types/eslint`, so this type package is unnecessary as long as we use the latest `eslint`.

Ref: https://github.com/eslint/eslint/blob/main/lib/types/index.d.ts#L2-L4

I've also bumped the version of Mocha to v11, which has no breaking changes for us, since it only upgrades the Node.js version requirement, which is compatible with `@eslint/markdown`.

Ref: https://github.com/mochajs/mocha/releases/tag/v11.0.0

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
