### PR TITLE
feat: add JSON frontmatter support to no-multiple-h1 rule

### DIFF
--- a/docs/rules/no-multiple-h1.md
+++ b/docs/rules/no-multiple-h1.md
@@ -12,7 +12,7 @@ This rule warns when it finds more than one H1 heading in a Markdown document. I
 
 - ATX-style headings (`# Heading`)
 - Setext-style headings (`Heading\n=========`)
-- Front matter title fields (YAML and TOML)
+- Front matter title fields (YAML, TOML, and JSON)
 - HTML h1 tags (`<h1>Heading</h1>`)
 
 Examples of **incorrect** code for this rule:
@@ -46,7 +46,7 @@ Another H1 heading
 
 The following options are available on this rule:
 
-* `frontmatterTitle: string` - A regex pattern to match title fields in front matter. The default pattern matches both YAML (`title:`) and TOML (`title =`) formats. Set to an empty string to disable front matter title checking.
+* `frontmatterTitle: string` - A regex pattern to match title fields in front matter. The default pattern matches YAML (`title:`), TOML (`title =`), and JSON (`"title":`) formats. Set to an empty string to disable front matter title checking.
 
 Examples of **incorrect** code for this rule:
 

--- a/src/rules/no-multiple-h1.js
+++ b/src/rules/no-multiple-h1.js
@@ -98,6 +98,12 @@ export default {
 				}
 			},
 
+			json(node) {
+				if (frontmatterHasTitle(node.value, titlePattern)) {
+					h1Count++;
+				}
+			},
+
 			html(node) {
 				let match;
 				while ((match = h1TagPattern.exec(node.value)) !== null) {

--- a/tests/rules/no-multiple-h1.test.js
+++ b/tests/rules/no-multiple-h1.test.js
@@ -85,6 +85,19 @@ ruleTester.run("no-multiple-h1", rule, {
 		{
 			code: dedent`
 				---
+				{
+					"title": "My Title"
+				}
+				---
+				## Heading 2
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+		},
+		{
+			code: dedent`
+				---
 				# title: My Title
 				---
 				# Heading 1
@@ -153,6 +166,20 @@ ruleTester.run("no-multiple-h1", rule, {
 		{
 			code: dedent`
 				---
+				{
+					"heading": "My Title"
+				}
+				---
+				## Heading 2
+			`,
+			options: [{ frontmatterTitle: '^\\s*"heading"\\s*:' }],
+			languageOptions: {
+				frontmatter: "json",
+			},
+		},
+		{
+			code: dedent`
+				---
 				author: Pixel998
 				---
 				# Heading 1
@@ -170,6 +197,19 @@ ruleTester.run("no-multiple-h1", rule, {
 			`,
 			languageOptions: {
 				frontmatter: "toml",
+			},
+		},
+		{
+			code: dedent`
+				---
+				{
+					"author": "Pixel998"
+				}
+				---
+				# Heading 1
+			`,
+			languageOptions: {
+				frontmatter: "json",
 			},
 		},
 		{
@@ -194,6 +234,20 @@ ruleTester.run("no-multiple-h1", rule, {
 			options: [{ frontmatterTitle: "" }],
 			languageOptions: {
 				frontmatter: "toml",
+			},
+		},
+		{
+			code: dedent`
+				---
+				{
+					"title": "My Title"
+				}
+				---
+				# Heading 1
+			`,
+			options: [{ frontmatterTitle: "" }],
+			languageOptions: {
+				frontmatter: "json",
 			},
 		},
 		'<h1 class="title">Heading</h1>',
@@ -425,6 +479,28 @@ ruleTester.run("no-multiple-h1", rule, {
 		{
 			code: dedent`
 				---
+				{
+					"title": "My Title"
+				}
+				---
+				# Heading 1
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 6,
+					column: 1,
+					endLine: 6,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
 				'title': My Title
 				---
 				# Heading 1
@@ -458,6 +534,28 @@ ruleTester.run("no-multiple-h1", rule, {
 					line: 4,
 					column: 1,
 					endLine: 4,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
+				{
+					'title': 'My Title'
+				}
+				---
+				# Heading 1
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 6,
+					column: 1,
+					endLine: 6,
 					endColumn: 12,
 				},
 			],
@@ -507,6 +605,29 @@ ruleTester.run("no-multiple-h1", rule, {
 		{
 			code: dedent`
 				---
+				{
+					"author": "Pixel998"
+					"title": "My Title"
+				}
+				---
+				# Heading 1
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 7,
+					column: 1,
+					endLine: 7,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
 				TITLE: My Title
 				---
 				# Heading 1
@@ -540,6 +661,28 @@ ruleTester.run("no-multiple-h1", rule, {
 					line: 4,
 					column: 1,
 					endLine: 4,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
+				{
+					"TITLE": "My Title"
+				}
+				---
+				# Heading 1
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 6,
+					column: 1,
+					endLine: 6,
 					endColumn: 12,
 				},
 			],
@@ -589,6 +732,29 @@ ruleTester.run("no-multiple-h1", rule, {
 		{
 			code: dedent`
 				---
+				{
+					"heading": "My Title"
+				}
+				---
+				# Heading 1
+			`,
+			options: [{ frontmatterTitle: '^\\s*"heading"\\s*:' }],
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 6,
+					column: 1,
+					endLine: 6,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
 				title: My Title
 				---
 				# Heading 1
@@ -626,6 +792,30 @@ ruleTester.run("no-multiple-h1", rule, {
 					line: 5,
 					column: 1,
 					endLine: 5,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
+				{
+					"title": "My Title"
+				}
+				---
+				# Heading 1
+				# Another H1
+			`,
+			options: [{ frontmatterTitle: "" }],
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 7,
+					column: 1,
+					endLine: 7,
 					endColumn: 13,
 				},
 			],
@@ -765,6 +955,37 @@ ruleTester.run("no-multiple-h1", rule, {
 					line: 6,
 					column: 1,
 					endLine: 6,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: dedent`
+				---
+				{
+					"title": "My Title"
+				}
+				---
+				# Heading 1
+				
+				<h1>Another H1</h1>
+			`,
+			languageOptions: {
+				frontmatter: "json",
+			},
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 6,
+					column: 1,
+					endLine: 6,
+					endColumn: 12,
+				},
+				{
+					messageId: "multipleH1",
+					line: 8,
+					column: 1,
+					endLine: 8,
 					endColumn: 20,
 				},
 			],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add JSON frontmatter support to no-multiple-h1 rule

#### What changes did you make? (Give an overview)

- Added JSON frontmatter support to the no-multiple-h1
- Added tests
- Updated documentation

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
