### PR TITLE
feat: add no-bare-urls rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ export default defineConfig([
 | :- | :- | :-: |
 | [`fenced-code-language`](./docs/rules/fenced-code-language.md) | Require languages for fenced code blocks | yes |
 | [`heading-increment`](./docs/rules/heading-increment.md) | Enforce heading levels increment by one | yes |
+| [`no-bare-urls`](./docs/rules/no-bare-urls.md) | Disallow bare URLs | no |
 | [`no-duplicate-definitions`](./docs/rules/no-duplicate-definitions.md) | Disallow duplicate definitions | yes |
 | [`no-duplicate-headings`](./docs/rules/no-duplicate-headings.md) | Disallow duplicate headings in the same document | no |
 | [`no-empty-definitions`](./docs/rules/no-empty-definitions.md) | Disallow empty definitions | yes |

--- a/docs/rules/no-bare-urls.md
+++ b/docs/rules/no-bare-urls.md
@@ -15,7 +15,7 @@ A bare URL appears without angle brackets (`<>`), such as `https://example.com/`
 
 > [!IMPORTANT] <!-- eslint-disable-line -- This should be fixed in https://github.com/eslint/markdown/issues/294 -->
 >
-> This rule relies on bare URLs being link nodes, which requires a GFM-compatible parser (e.g., `language: "markdown/gfm"`).
+> This rule requires `language: "markdown/gfm"`.
 
 This rule flags bare URLs that should be formatted as autolinks or links.
 
@@ -27,6 +27,10 @@ Examples of **incorrect** code for this rule:
 For more info, visit https://www.example.com/
 
 Contact us at user@example.com
+
+[Read the [docs]](https://www.example.com/)
+
+[docs]: https://www.example.com/docs
 ```
 
 Examples of **correct** code for this rule:
@@ -41,6 +45,12 @@ For more info, visit [Example Website](https://www.example.com/)
 Contact us at <user@example.com>
 
 Contact us at [user@example.com](mailto:user@example.com)
+
+Not a clickable link: `https://www.example.com/`
+
+[https://www.example.com/]
+
+[Read the \[docs\]](https://www.example.com/)
 ```
 
 ## When Not to Use It

--- a/docs/rules/no-bare-urls.md
+++ b/docs/rules/no-bare-urls.md
@@ -1,0 +1,53 @@
+# no-bare-urls
+
+Disallow bare URLs.
+
+## Background
+
+In Markdown, URLs are typically formatted in two ways:
+
+1. Autolinks: URLs wrapped in angle brackets, such as `<https://example.com/>`
+2. Links: URLs with descriptive text, such as `[Visit our website](https://example.com/)`
+
+A bare URL appears without angle brackets (`<>`), such as `https://example.com/`. While GitHub Flavored Markdown (GFM) allows bare URLs to be recognized as clickable links, this feature is not supported in all Markdown processors. To ensure compatibility across different processors, use autolinks or links instead.
+
+## Rule Details
+
+> [!IMPORTANT] <!-- eslint-disable-line -- This should be fixed in https://github.com/eslint/markdown/issues/294 -->
+>
+> This rule relies on bare URLs being link nodes, which requires a GFM-compatible parser (e.g., `language: "markdown/gfm"`).
+
+This rule flags bare URLs that should be formatted as autolinks or links.
+
+Examples of **incorrect** code for this rule:
+
+```markdown
+<!-- eslint markdown/no-bare-urls: "error" -->
+
+For more info, visit https://www.example.com/
+
+Contact us at user@example.com
+```
+
+Examples of **correct** code for this rule:
+
+```markdown
+<!-- eslint markdown/no-bare-urls: "error" -->
+
+For more info, visit <https://www.example.com/>
+
+For more info, visit [Example Website](https://www.example.com/)
+
+Contact us at <user@example.com>
+
+Contact us at [user@example.com](mailto:user@example.com)
+```
+
+## When Not to Use It
+
+If you're working in an environment where GFM autolink literals are fully supported and you prefer their simplicity, you can safely disable this rule.
+
+## Prior Art
+
+* [remark-lint-no-literal-urls](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls)
+* [MD034 - Bare URL used](https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md)

--- a/docs/rules/no-bare-urls.md
+++ b/docs/rules/no-bare-urls.md
@@ -28,6 +28,8 @@ For more info, visit https://www.example.com/
 
 Contact us at user@example.com
 
+# https://www.example.com/
+
 [Read the [docs]](https://www.example.com/)
 
 [docs]: https://www.example.com/docs
@@ -45,6 +47,8 @@ For more info, visit [Example Website](https://www.example.com/)
 Contact us at <user@example.com>
 
 Contact us at [user@example.com](mailto:user@example.com)
+
+# <https://www.example.com/>
 
 Not a clickable link: `https://www.example.com/`
 

--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Rule to prevent bare URLs in Markdown.
+ * @author xbinaryx
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("mdast").Paragraph} ParagraphNode */
+/** @typedef {import("mdast").TableCell} TableCellNode */
+/**
+ * @typedef {import("../types.ts").MarkdownRuleDefinition<{ RuleOptions: []; }>}
+ * NoBareUrlsRuleDefinition
+ */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const htmlTagPattern = /^<([^!>][^/\s>]*)/u;
+
+/**
+ * Parses an HTML tag to extract its name and closing status
+ * @param {string} tagText The HTML tag text to parse
+ * @returns {{ name: string; isClosing: boolean; } | null} Object containing tag name and closing status, or null if not a valid tag
+ */
+function parseHtmlTag(tagText) {
+	const match = tagText.match(htmlTagPattern);
+	if (match) {
+		const tagName = match[1].toLowerCase();
+		const isClosing = tagName.startsWith("/");
+
+		return {
+			name: isClosing ? tagName.slice(1) : tagName,
+			isClosing,
+		};
+	}
+
+	return null;
+}
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {NoBareUrlsRuleDefinition} */
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			description: "Disallow bare URLs",
+			url: "https://github.com/eslint/markdown/blob/main/docs/rules/no-bare-urls.md",
+		},
+
+		fixable: "code",
+
+		messages: {
+			bareUrl:
+				"Unexpected bare URL. Use autolink (<URL>) or link ([text](URL)) instead.",
+		},
+	},
+
+	create(context) {
+		const { sourceCode } = context;
+		const bareUrls = [];
+
+		/**
+		 * Finds bare URLs in markdown nodes while handling HTML tags.
+		 * When an HTML tag is found, it looks for its closing tag and skips all nodes
+		 * between them to prevent checking for bare URLs inside HTML content.
+		 * @param {ParagraphNode|TableCellNode} node The node to process
+		 * @returns {void}
+		 */
+		function findBareUrls(node) {
+			if (!node.children) {
+				return;
+			}
+
+			for (let i = 0; i < node.children.length; i++) {
+				const child = node.children[i];
+
+				if (child.type === "html") {
+					const tagInfo = parseHtmlTag(sourceCode.getText(child));
+
+					if (tagInfo && !tagInfo.isClosing) {
+						for (let j = i + 1; j < node.children.length; j++) {
+							const nextChild = node.children[j];
+							if (nextChild.type === "html") {
+								const closingTagInfo = parseHtmlTag(
+									sourceCode.getText(nextChild),
+								);
+								if (
+									closingTagInfo?.name === tagInfo.name &&
+									closingTagInfo?.isClosing
+								) {
+									i = j;
+									break;
+								}
+							}
+						}
+					}
+				} else if (child.type === "link") {
+					const text = sourceCode.getText(child);
+					const { url } = child;
+
+					if (
+						text === url ||
+						url === `http://${text}` ||
+						url === `mailto:${text}`
+					) {
+						bareUrls.push(child);
+					}
+				}
+			}
+		}
+
+		return {
+			"root:exit"() {
+				for (const bareUrl of bareUrls) {
+					context.report({
+						node: bareUrl,
+						messageId: "bareUrl",
+						fix(fixer) {
+							const text = sourceCode.getText(bareUrl);
+							return fixer.replaceText(bareUrl, `<${text}>`);
+						},
+					});
+				}
+			},
+
+			paragraph(node) {
+				findBareUrls(node);
+			},
+
+			tableCell(node) {
+				findBareUrls(node);
+			},
+		};
+	},
+};

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -249,6 +249,19 @@ ruleTester.run("no-bare-urls", rule, {
 			],
 		},
 		{
+			code: "Text <a>https://example.com</a> https://example.com",
+			output: "Text <a>https://example.com</a> <https://example.com>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 33,
+					endLine: 1,
+					endColumn: 52,
+				},
+			],
+		},
+		{
 			code: "<br> Another violation: https://example.com. <br>",
 			output: "<br> Another violation: <https://example.com>. <br>",
 			errors: [

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -1,0 +1,309 @@
+/**
+ * @fileoverview Tests for no-bare-urls rule.
+ * @author xbinaryx
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-bare-urls.js";
+import markdown from "../../src/index.js";
+import { RuleTester } from "eslint";
+import dedent from "dedent";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		markdown,
+	},
+	language: "markdown/gfm",
+});
+
+ruleTester.run("no-bare-urls", rule, {
+	valid: [
+		"<https://www.google.com/>",
+		"<user@example.com>",
+		"[text [undefined] text](https://example.com).",
+		"[is-a-valid]: https://example.com",
+		'<a href="https://example.com">link</a>.',
+		'<a href="https://example.com">https://example.com</a>',
+		'<a href="https://example.com">Text https://example.com</a>',
+		"This is not a bare [link]( https://example.com )",
+		"Nor is [link](https://example.com/path-with(parens)).",
+		"Or <https://example.com/path-with(parens)>.",
+		dedent`
+        <element-name first-attribute=" https://example.com/first " second-attribute=" https://example.com/second ">
+            Text
+        </element-name>`,
+		dedent`
+        <element-name
+            first-attribute=" https://example.com/first "
+            second-attribute=" https://example.com/second "></element-name>`,
+		"Not <code>https://example.com</code> bare.",
+		"Not <pre>https://example.com</pre> bare.",
+		dedent`
+        <p>
+        Not bare due to being in an HTML block:
+        https://example.com
+        <code>https://example.com</code>
+        <pre>https://example.com</pre>
+        </p>`,
+		dedent`
+        <div>
+        https://example.com
+        </div>`,
+		dedent`
+        <div>
+        https://example.com
+
+        </div>`,
+		"Text [link to https://example.com site](https://example.com) text.",
+		"Image ![for https://example.com site](https://example.com) text.",
+		"Links with spaces inside angle brackets are okay: [blue jay](<https://en.wikipedia.org/wiki/Blue jay>)",
+		"[link \\[is-not-a-valid\\] link](https://example.com)",
+		"text <https://example.com/dir/dir>",
+		dedent`
+        \`\`\`text
+        Code https://example.com/code?type=fence code
+        \`\`\``,
+		"       Code https://example.com/code?type=indent code",
+	],
+	invalid: [
+		{
+			code: "https://www.example.com/",
+			output: "<https://www.example.com/>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
+		{
+			code: "user@example.com",
+			output: "<user@example.com>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "text https://www.google.com/",
+			output: "text <https://www.google.com/>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 6,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "hTtPs://gOoGlE.cOm/",
+			output: "<hTtPs://gOoGlE.cOm/>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: "(https://example.com)",
+			output: "(<https://example.com>)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: dedent`
+            | Link                 |
+            |----------------------|
+            | https://example.com/ |`,
+			output: dedent`
+            | Link                 |
+            |----------------------|
+            | <https://example.com/> |`,
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: dedent`
+            [link that [is-a-valid] link](https://example.com)
+            
+            [is-a-valid]: https://example.com
+            `,
+			output: dedent`
+            [link that [is-a-valid] link](<https://example.com>)
+            
+            [is-a-valid]: https://example.com
+            `,
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 50,
+				},
+			],
+		},
+		{
+			code: "Text <https://example.com/brackets> text https://example.com/bare text",
+			output: "Text <https://example.com/brackets> text <https://example.com/bare> text",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 66,
+				},
+			],
+		},
+		{
+			code: "> https://example.com/",
+			output: "> <https://example.com/>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: "Text https://example.com/first more text https://example.com/second",
+			output: "Text <https://example.com/first> more text <https://example.com/second>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 6,
+					endLine: 1,
+					endColumn: 31,
+				},
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 68,
+				},
+			],
+		},
+		{
+			code: dedent`
+            Text https://example.com/first
+            more text https://example.com/second`,
+			output: dedent`
+            Text <https://example.com/first>
+            more text <https://example.com/second>`,
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 6,
+					endLine: 1,
+					endColumn: 31,
+				},
+				{
+					messageId: "bareUrl",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 37,
+				},
+			],
+		},
+		{
+			code: "<br> Another violation: https://example.com. <br>",
+			output: "<br> Another violation: <https://example.com>. <br>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 25,
+					endLine: 1,
+					endColumn: 44,
+				},
+			],
+		},
+		{
+			code: dedent`
+            <div>
+            
+            https://example.com
+            </div>`,
+			output: dedent`
+            <div>
+            
+            <https://example.com>
+            </div>`,
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: dedent`
+            <div>
+            
+            https://example.com
+
+            </div>`,
+			output: dedent`
+            <div>
+            
+            <https://example.com>
+
+            </div>`,
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 20,
+				},
+			],
+		},
+	],
+});

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -139,6 +139,19 @@ ruleTester.run("no-bare-urls", rule, {
 			],
 		},
 		{
+			code: "# https://www.example.com/",
+			output: "# <https://www.example.com/>",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
 			code: dedent`
             | Link                 |
             |----------------------|
@@ -315,6 +328,19 @@ ruleTester.run("no-bare-urls", rule, {
 					column: 1,
 					endLine: 3,
 					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: "text **<a>https://example.com</a>** *https://example.com*",
+			output: "text **<a>https://example.com</a>** *<https://example.com>*",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 38,
+					endLine: 1,
+					endColumn: 57,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR implements the `no-bare-urls` rule to enforce proper URL formatting in Markdown documents. The rule ensures URLs are either wrapped in angle brackets (autolinks) or used with text (links), rather than being used as bare URLs.

#### What changes did you make? (Give an overview)

Implemented the `no-bare-urls` rule, along with documentation and tests.

#### Related Issues

Fixes #399

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
