### PR TITLE
chore: update lint-staged to run `git add README.md` when rules change

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
       "eslint --fix -c eslint.config-content.js"
     ],
     "!(*.{js,md})": "prettier --write --ignore-unknown",
-    "{src/rules/*.js,tools/update-rules-docs.js,README.md}": "npm run build:update-rules-docs"
+    "{src/rules/*.js,tools/update-rules-docs.js,README.md}": [
+      "npm run build:update-rules-docs",
+      "git add README.md"
+    ]
   },
   "scripts": {
     "lint": "eslint . && eslint -c eslint.config-content.js .",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I’ve updated lint-staged to also run `git add README.md` when the rules change.

Currently, when the rules change, only the `npm run build:update-rules-docs` script runs, so users have to manually add the updated `README.md` to the Git.

This approach has been used in the CSS repository, as shown below:

https://github.com/eslint/css/blob/main/package.json#L57-L60

![image](https://github.com/user-attachments/assets/3321c34a-97f0-40ad-bc2a-a7e847e01595)

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
