### PR TITLE
refactor: add default options for `fenced-code-language` and `no-html`

### DIFF
--- a/docs/rules/fenced-code-language.md
+++ b/docs/rules/fenced-code-language.md
@@ -34,7 +34,7 @@ console.log(message);
 
 The following options are available on this rule:
 
-* `required: Array<string>` - when specified, fenced code blocks must use one of the languages specified in this array. 
+* `required: Array<string>` - when specified, fenced code blocks must use one of the languages specified in this array. (default: `[]`)
 
 Examples of **incorrect** code when configured as `"fenced-code-language": ["error", { required: ["js"] }]`:
 

--- a/docs/rules/no-html.md
+++ b/docs/rules/no-html.md
@@ -24,7 +24,7 @@ Hello <b>world!</b>
 
 The following options are available on this rule:
 
-* `allowed: Array<string>` - when specified, HTML tags are allowed only if they match one of the tags in this array.
+* `allowed: Array<string>` - when specified, HTML tags are allowed only if they match one of the tags in this array. (default: `[]`)
 
 Examples of **incorrect** code when configured as `"no-html": ["error", { allowed: ["b"] }]`:
 

--- a/src/rules/fenced-code-language.js
+++ b/src/rules/fenced-code-language.js
@@ -54,6 +54,12 @@ export default {
 				additionalProperties: false,
 			},
 		],
+
+		defaultOptions: [
+			{
+				required: [],
+			},
+		],
 	},
 
 	create(context) {

--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -57,6 +57,12 @@ export default {
 				additionalProperties: false,
 			},
 		],
+
+		defaultOptions: [
+			{
+				allowed: [],
+			},
+		],
 	},
 
 	create(context) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I’ve added the `defaultOptions` field to `meta` for `fenced-code-language` and `no-html`.

I noticed that recently added rules include the `defaultOptions` field in `meta`, but these two did not.

This change doesn’t affect the functionality of the rules.

#### What changes did you make? (Give an overview)

I’ve added the `defaultOptions` field to `meta` for `fenced-code-language` and `no-html`.

#### Related Issues

Nothing.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Nothing.

<!-- markdownlint-disable-file MD004 -->
