### PR TITLE
test: correct indentation in `fenced-code-language` test cases

### DIFF
--- a/tests/rules/fenced-code-language.test.js
+++ b/tests/rules/fenced-code-language.test.js
@@ -26,19 +26,19 @@ ruleTester.run("fenced-code-language", rule, {
 	valid: [
 		// backtick code block
 		`\`\`\`js
-        console.log("Hello, world!");
-        \`\`\``,
+console.log("Hello, world!");
+\`\`\``,
 		`\`\`\`javascript
-        console.log("Hello, world!");
-        \`\`\``,
+console.log("Hello, world!");
+\`\`\``,
 
 		// tilde code block
 		`~~~js
-        console.log("Hello, world!");
-        ~~~`,
+console.log("Hello, world!");
+~~~`,
 		`~~~javascript
-        console.log("Hello, world!");
-        ~~~`,
+console.log("Hello, world!");
+~~~`,
 
 		// indented code block
 		`
@@ -46,52 +46,53 @@ ruleTester.run("fenced-code-language", rule, {
         `,
 		{
 			code: `\`\`\`js
-                console.log("Hello, world!");
-                \`\`\``,
+console.log("Hello, world!");
+\`\`\``,
 			options: [{ required: ["js"] }],
 		},
 	],
 	invalid: [
 		{
 			code: `\`\`\`
-                console.log("Hello, world!");
-                \`\`\``,
+console.log("Hello, world!");
+\`\`\``,
 			errors: [
 				{
 					messageId: "missingLanguage",
 					line: 1,
 					column: 1,
 					endLine: 3,
-					endColumn: 20,
+					endColumn: 4,
 				},
 			],
 		},
 		{
 			code: `~~~
-                console.log("Hello, world!");
-                ~~~`,
+console.log("Hello, world!");
+~~~`,
 			errors: [
 				{
 					messageId: "missingLanguage",
 					line: 1,
 					column: 1,
 					endLine: 3,
-					endColumn: 20,
+					endColumn: 4,
 				},
 			],
 		},
 		{
 			code: `\`\`\`javascript
-                console.log("Hello, world!");
-                \`\`\``,
+console.log("Hello, world!");
+\`\`\``,
 			options: [{ required: ["js"] }],
 			errors: [
 				{
 					messageId: "disallowedLanguage",
+					data: { lang: "javascript" },
 					line: 1,
 					column: 1,
 					endLine: 3,
-					endColumn: 20,
+					endColumn: 4,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've corrected indentation in `fenced-code-language` test cases.

Currently, template literal like below yields a [AST](https://explorer.eslint.org/#eslint-explorer=IntcInN0YXRlXCI6e1widG9vbFwiOlwiYXN0XCIsXCJjb2RlXCI6e1wiamF2YXNjcmlwdFwiOlwiLyoqXFxuICogVHlwZSBvciBwYXN0ZSBzb21lIEphdmFTY3JpcHQgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxuICogdGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG4gKiBcXG4gKiBUaGUgdGhyZWUgdGFicyBhcmU6XFxuICogXFxuICogLSBBU1QgLSBUaGUgQWJzdHJhY3QgU3ludGF4IFRyZWUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhblxcbiAqICAgYmUgdXNlZnVsIHRvIHVuZGVyc3RhbmQgdGhlIHN0cnVjdHVyZSBvZiB0aGUgY29kZS4gWW91XFxuICogICBjYW4gdmlldyB0aGlzIHN0cnVjdHVyZSBhcyBKU09OIG9yIGluIGEgdHJlZSBmb3JtYXQuXFxuICogLSBTY29wZSAtIFRoZSBzY29wZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhbiBiZVxcbiAqICAgdXNlZnVsIHRvIHVuZGVyc3RhbmQgaG93IHZhcmlhYmxlcyBhcmUgZGVmaW5lZCBhbmRcXG4gKiAgIHdoZXJlIHRoZXkgYXJlIHVzZWQuXFxuICogLSBDb2RlIFBhdGggLSBUaGUgY29kZSBwYXRoIHN0cnVjdHVyZSBvZiB0aGUgY29kZSwgd2hpY2hcXG4gKiAgIGNhbiBiZSB1c2VmdWwgdG8gdW5kZXJzdGFuZCBob3cgdGhlIGNvZGUgaXMgZXhlY3V0ZWQuXFxuICogXFxuICogWW91IGNhbiBjaGFuZ2UgdGhlIHdheSB0aGF0IHRoZSBKYXZhU2NyaXB0IGNvZGUgaXMgaW50ZXJwcmV0ZWRcXG4gKiBieSBjbGlja2luZyBcXFwiSmF2YVNjcmlwdFxcXCIgaW4gdGhlIGhlYWRlciBhbmQgc2VsZWN0aW5nIGRpZmZlcmVudFxcbiAqIG9wdGlvbnMuXFxuICovXFxuXFxuaW1wb3J0IGpzIGZyb20gXFxcIkBlc2xpbnQvanNcXFwiO1xcblxcbmZ1bmN0aW9uIGdldENvbmZpZygpIHtcXG4gICAgcmV0dXJuIHtcXG4gICAgICAgIHJ1bGVzOiB7XFxuICAgICAgICAgICAgXFxcInByZWZlci1jb25zdFxcXCI6IFxcXCJ3YXJuXFxcIlxcbiAgICAgICAgfVxcbiAgICB9O1xcbn1cXG5cXG5leHBvcnQgZGVmYXVsdCBbXFxuICAgIC4uLmpzLmNvbmZpZ3MucmVjb21tZW5kZWQsXFxuICAgIGdldENvbmZpZygpXFxuXTtcIixcImpzb25cIjpcIntcXG5mb286IFxcXCJiYXJcXFwiXFxufVwiLFwibWFya2Rvd25cIjpcImBgYGpzXFxuICAgICAgICBjb25zb2xlLmxvZyhcXFwiSGVsbG8sIHdvcmxkIVxcXCIpO1xcbiAgICAgICAgYGBgXCIsXCJjc3NcIjpcIi8qKlxcbiAqIFR5cGUgb3IgcGFzdGUgc29tZSBDU1MgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxuICogdGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG4gKlxcbiAqIFRoZSB0YWJzIGFyZTpcXG4gKlxcbiAqIC0gQVNUIC0gVGhlIEFic3RyYWN0IFN5bnRheCBUcmVlIG9mIHRoZSBjb2RlLCB3aGljaCBjYW5cXG4gKiAgIGJlIHVzZWZ1bCB0byB1bmRlcnN0YW5kIHRoZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUuIFlvdVxcbiAqICAgY2FuIHZpZXcgdGhpcyBzdHJ1Y3R1cmUgYXMgSlNPTiBvciBpbiBhIHRyZWUgZm9ybWF0LlxcbiAqXFxuICogWW91IGNhbiBjaGFuZ2UgdGhlIHdheSB0aGF0IHRoZSBDU1MgY29kZSBpcyBpbnRlcnByZXRlZFxcbiAqIGJ5IGNsaWNraW5nIFxcXCJDU1NcXFwiIGluIHRoZSBoZWFkZXIgYW5kIHNlbGVjdGluZyBkaWZmZXJlbnRcXG4gKiBvcHRpb25zLlxcbiAqL1xcblxcbkBpbXBvcnQgdXJsKCdodHRwczovL2ZvbnRzLmdvb2dsZWFwaXMuY29tL2NzczI%2FZmFtaWx5PVJvYm90bzp3Z2h0QDQwMDs3MDAmZGlzcGxheT1zd2FwJyk7XFxuXFxuYm9keSB7XFxuXFx0Zm9udC1mYW1pbHk6IHNhbnMtc2VyaWY7XFxufVxcblxcbmgxIHtcXG5cXHRjb2xvcjogIzMzMztcXG59XFxuXFxucCB7XFxuXFx0bWFyZ2luOiAxZW0gMDtcXG59XCIsXCJodG1sXCI6XCI8IURPQ1RZUEUgaHRtbD5cXG48IS0tXFxuVHlwZSBvciBwYXN0ZSBzb21lIEhUTUwgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxudGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG5cXG5UaGUgdGFicyBhcmU6XFxuXFxuLSBBU1QgLSBUaGUgQWJzdHJhY3QgU3ludGF4IFRyZWUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhblxcbmJlIHVzZWZ1bCB0byB1bmRlcnN0YW5kIHRoZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUuIFlvdVxcbmNhbiB2aWV3IHRoaXMgc3RydWN0dXJlIGFzIEpTT04gb3IgaW4gYSB0cmVlIGZvcm1hdC5cXG4tLT5cXG5cXG48aHRtbCBsYW5nPVxcXCJlblxcXCI%2BXFxuICAgIDxoZWFkPlxcbiAgICAgICAgPG1ldGEgY2hhcnNldD1cXFwiVVRGLThcXFwiPlxcbiAgICAgICAgPHRpdGxlPkhUTUw8L3RpdGxlPlxcbiAgICA8L2hlYWQ%2BXFxuICAgIDxib2R5PlxcbiAgICAgICAgPHA%2BVGV4dDwvcD5cXG4gICAgPC9ib2R5PlxcbjwvaHRtbD5cIn0sXCJsYW5ndWFnZVwiOlwibWFya2Rvd25cIixcImpzT3B0aW9uc1wiOntcInBhcnNlclwiOlwiZXNwcmVlXCIsXCJzb3VyY2VUeXBlXCI6XCJtb2R1bGVcIixcImVzVmVyc2lvblwiOlwibGF0ZXN0XCIsXCJpc0pTWFwiOnRydWV9LFwianNvbk9wdGlvbnNcIjp7XCJqc29uTW9kZVwiOlwianNvbjVcIixcImFsbG93VHJhaWxpbmdDb21tYXNcIjpmYWxzZX0sXCJjc3NPcHRpb25zXCI6e1wiY3NzTW9kZVwiOlwiY3NzXCIsXCJ0b2xlcmFudFwiOmZhbHNlfSxcIm1hcmtkb3duT3B0aW9uc1wiOntcIm1hcmtkb3duTW9kZVwiOlwiY29tbW9ubWFya1wiLFwibWFya2Rvd25Gcm9udG1hdHRlclwiOlwib2ZmXCJ9LFwid3JhcFwiOnRydWUsXCJ2aWV3TW9kZXNcIjp7XCJhc3RWaWV3XCI6XCJ0cmVlXCIsXCJzY29wZVZpZXdcIjpcImZsYXRcIixcInBhdGhWaWV3XCI6XCJncmFwaFwifSxcInBhdGhJbmRleFwiOntcImluZGV4XCI6MCxcImluZGV4ZXNcIjoyfSxcImVzcXVlcnlTZWxlY3RvclwiOntcInNlbGVjdG9yXCI6XCJcIn19LFwidmVyc2lvblwiOjB9Ig%3D%3D) like below:

````js
`\`\`\`js
        console.log("Hello, world!");
        \`\`\``
````

![image](https://github.com/user-attachments/assets/38c5fbe4-7cf4-47a6-8cc6-7f2e5441d820)

The trailing triple backticks or tildes are not recognized as a valid closing delimiter for the code block because they are indented within the template literal.

As a result, they are treated as part of the code content rather than as the closing of the code block.

FYI, It currently works as expected, but I believe the original intention of the trailing triple backticks or tildes was to close the code block, not to be included as part of the code content.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
