### PR TITLE
fix: update `no-duplicate-headings` to align with CommonMark spec

### DIFF
--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -14,6 +14,12 @@
  */
 
 //-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const closingAtxHashPattern = /[ \t]+#+[ \t]*$/u;
+
+//-----------------------------------------------------------------------------
 // Rule Definition
 //-----------------------------------------------------------------------------
 
@@ -74,10 +80,10 @@ export default {
 			 * - ATX headings, which consist of 1-6 # characters followed by content
 			 *   and optionally ending with any number of # characters
 			 * - Setext headings, which are underlined with = or -
-			 * Setext headings are identified by being on two lines instead of one,
-			 * with the second line containing only = or - characters. In order to
-			 * get the correct heading text, we need to determine which type of
-			 * heading we're dealing with.
+			 *   Setext headings are identified by being on two lines instead of one,
+			 *   with the second line containing only = or - characters. In order to
+			 *   get the correct heading text, we need to determine which type of
+			 *   heading we're dealing with.
 			 */
 			const isSetext =
 				node.position.start.line !== node.position.end.line;
@@ -90,8 +96,8 @@ export default {
 			// For ATX headings, get the text between the # characters
 			const text = sourceCode.getText(node);
 			return text
-				.slice(node.depth)
-				.replace(/\s+#+\s*$/u, "")
+				.slice(node.depth) // Remove leading # characters
+				.replace(closingAtxHashPattern, "") // Remove trailing # characters
 				.trim();
 		}
 

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -35,6 +35,7 @@
  * @see https://spec.commonmark.org/0.31.2/#example-76
  */
 const closingAtxHeadingHashPattern = /[ \t]+#+[ \t]*$/u;
+const openingAtxHeadingHashPattern = /^#{1,6}[ \t]+/u;
 
 //-----------------------------------------------------------------------------
 // Rule Definition
@@ -106,7 +107,11 @@ export default {
 				node.position.start.line !== node.position.end.line;
 
 			if (isSetext) {
-				// get only the text from the first line
+				/*
+				 * - Get only the text from the first line.
+				 * - Please avoid using `String.prototype.trim()` here,
+				 *   as it would remove intentional non-breaking space (NBSP) characters.
+				 */
 				return sourceCode.lines[node.position.start.line - 1].trim();
 			}
 
@@ -118,9 +123,8 @@ export default {
 			 * as it would remove intentional non-breaking space (NBSP) characters.
 			 */
 			return text
-				.slice(node.depth) // Remove leading # characters
-				.replace(closingAtxHeadingHashPattern, "") // Remove trailing # characters
-				.trim();
+				.replace(openingAtxHeadingHashPattern, "") // Remove leading # characters
+				.replace(closingAtxHeadingHashPattern, ""); // Remove trailing # characters
 		}
 
 		return {

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -17,7 +17,7 @@
 // Helpers
 //-----------------------------------------------------------------------------
 
-const closingAtxHashPattern = /[ \t]+#+[ \t]*$/u;
+const closingAtxHeadingHashPattern = /[ \t]+#+[ \t]*$/u;
 
 //-----------------------------------------------------------------------------
 // Rule Definition
@@ -97,7 +97,7 @@ export default {
 			const text = sourceCode.getText(node);
 			return text
 				.slice(node.depth) // Remove leading # characters
-				.replace(closingAtxHashPattern, "") // Remove trailing # characters
+				.replace(closingAtxHeadingHashPattern, "") // Remove trailing # characters
 				.trim();
 		}
 

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -112,6 +112,11 @@ export default {
 
 			// For ATX headings, get the text between the # characters
 			const text = sourceCode.getText(node);
+
+			/*
+			 * Please avoid using `String.prototype.trim()` here,
+			 * as it would remove intentional non-breaking space (NBSP) characters.
+			 */
 			return text
 				.slice(node.depth) // Remove leading # characters
 				.replace(closingAtxHeadingHashPattern, "") // Remove trailing # characters

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -17,6 +17,23 @@
 // Helpers
 //-----------------------------------------------------------------------------
 
+/**
+ * This pattern does not match backslash-escaped `#` characters
+ * @example
+ * ```markdown
+ * <!-- OK -->
+ * ### foo ###
+ * ## foo ###
+ * # foo #
+ *
+ * <!-- NOT OK -->
+ * ### foo \###
+ * ## foo #\##
+ * # foo \#
+ * ```
+ *
+ * @see https://spec.commonmark.org/0.31.2/#example-76
+ */
 const closingAtxHeadingHashPattern = /[ \t]+#+[ \t]*$/u;
 
 //-----------------------------------------------------------------------------

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -34,8 +34,8 @@
  *
  * @see https://spec.commonmark.org/0.31.2/#example-76
  */
-const closingAtxHeadingHashPattern = /[ \t]+#+[ \t]*$/u;
-const openingAtxHeadingHashPattern = /^#{1,6}[ \t]+/u;
+const trailingAtxHeadingHashPattern = /[ \t]+#+[ \t]*$/u;
+const leadingAtxHeadingHashPattern = /^#{1,6}[ \t]+/u;
 
 //-----------------------------------------------------------------------------
 // Rule Definition
@@ -74,6 +74,7 @@ export default {
 		const [{ checkSiblingsOnly }] = context.options;
 		const { sourceCode } = context;
 
+		/** @type {Map<number, Set<string>>} */
 		const headingsByLevel = checkSiblingsOnly
 			? new Map([
 					[1, new Set()],
@@ -123,8 +124,8 @@ export default {
 			 * as it would remove intentional non-breaking space (NBSP) characters.
 			 */
 			return text
-				.replace(openingAtxHeadingHashPattern, "") // Remove leading # characters
-				.replace(closingAtxHeadingHashPattern, ""); // Remove trailing # characters
+				.replace(leadingAtxHeadingHashPattern, "") // Remove leading # characters
+				.replace(trailingAtxHeadingHashPattern, ""); // Remove trailing # characters
 		}
 
 		return {

--- a/src/rules/no-duplicate-headings.js
+++ b/src/rules/no-duplicate-headings.js
@@ -108,11 +108,7 @@ export default {
 				node.position.start.line !== node.position.end.line;
 
 			if (isSetext) {
-				/*
-				 * - Get only the text from the first line.
-				 * - Please avoid using `String.prototype.trim()` here,
-				 *   as it would remove intentional non-breaking space (NBSP) characters.
-				 */
+				// get only the text from the first line
 				return sourceCode.lines[node.position.start.line - 1].trim();
 			}
 

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -35,7 +35,7 @@ ruleTester.run("no-duplicate-headings", rule, {
 
 			# Heading 1#
 		`,
-		"# Heading 1\n# \u00a0Heading 1",
+		"# Heading 1\n# \u00a0Heading 1", // We can't use `dedent` library when detecting NBSP(U+00A0) characters, as it automatically removes them.
 		"# Heading 1\n# Heading 1\u00a0",
 		"# Heading 1 #\n# \u00a0Heading 1 #",
 		"# Heading 1 #\n# Heading 1\u00a0 #",

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -42,6 +42,9 @@ ruleTester.run("no-duplicate-headings", rule, {
 		"# Heading 1 #\n# Heading 1\u00a0#",
 		"#  Heading 1  #\n# \u00a0Heading 1\u00a0#",
 		"# \u00a0Heading 1 #\n# Heading 1\u00a0 #",
+		"# foo \\###\n# foo ###",
+		"# foo #\\##\n# foo ###",
+		"# foo \\#",
 		{
 			code: dedent`
 				# Change log

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -35,7 +35,13 @@ ruleTester.run("no-duplicate-headings", rule, {
 
 			# Heading 1#
 		`,
-		"# Heading 1 #\n# Heading 1\u00a0#", // With non-breaking space
+		"# Heading 1\n# \u00a0Heading 1",
+		"# Heading 1\n# Heading 1\u00a0",
+		"# Heading 1 #\n# \u00a0Heading 1 #",
+		"# Heading 1 #\n# Heading 1\u00a0 #",
+		"# Heading 1 #\n# Heading 1\u00a0#",
+		"#  Heading 1  #\n# \u00a0Heading 1\u00a0#",
+		"# \u00a0Heading 1 #\n# Heading 1\u00a0 #",
 		{
 			code: dedent`
 				# Change log

--- a/tests/rules/no-duplicate-headings.test.js
+++ b/tests/rules/no-duplicate-headings.test.js
@@ -25,14 +25,17 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("no-duplicate-headings", rule, {
 	valid: [
-		`# Heading 1
+		dedent`
+			# Heading 1
 
-        ## Heading 2`,
+			## Heading 2
+        `,
 		dedent`
 			# Heading 1
 
 			# Heading 1#
 		`,
+		"# Heading 1 #\n# Heading 1\u00a0#", // With non-breaking space
 		{
 			code: dedent`
 				# Change log


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?


This PR is a follow-up to [#421](https://github.com/eslint/markdown/pull/421).

I’ve updated the `no-duplicate-headings` rule to align with the CommonMark specification.

According to CommonMark, only space (` `) and tab (`\t`) characters are considered valid whitespace for `Heading` nodes.

However, the current implementation of `no-duplicate-headings` automatically removes whitespace characters like NBSP, which can lead to unintended behavior that doesn’t conform to the CommonMark spec. This may cause confusion for users who intentionally use NBSP characters, especially those using the closing-style ATX headings.

Here's a brief example with NBSP:

[AST with NBSP](https://explorer.eslint.org/#eslint-explorer=IntcInN0YXRlXCI6e1widG9vbFwiOlwiYXN0XCIsXCJjb2RlXCI6e1wiamF2YXNjcmlwdFwiOlwiLyoqXFxuICogVHlwZSBvciBwYXN0ZSBzb21lIEphdmFTY3JpcHQgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxuICogdGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG4gKiBcXG4gKiBUaGUgdGhyZWUgdGFicyBhcmU6XFxuICogXFxuICogLSBBU1QgLSBUaGUgQWJzdHJhY3QgU3ludGF4IFRyZWUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhblxcbiAqICAgYmUgdXNlZnVsIHRvIHVuZGVyc3RhbmQgdGhlIHN0cnVjdHVyZSBvZiB0aGUgY29kZS4gWW91XFxuICogICBjYW4gdmlldyB0aGlzIHN0cnVjdHVyZSBhcyBKU09OIG9yIGluIGEgdHJlZSBmb3JtYXQuXFxuICogLSBTY29wZSAtIFRoZSBzY29wZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhbiBiZVxcbiAqICAgdXNlZnVsIHRvIHVuZGVyc3RhbmQgaG93IHZhcmlhYmxlcyBhcmUgZGVmaW5lZCBhbmRcXG4gKiAgIHdoZXJlIHRoZXkgYXJlIHVzZWQuXFxuICogLSBDb2RlIFBhdGggLSBUaGUgY29kZSBwYXRoIHN0cnVjdHVyZSBvZiB0aGUgY29kZSwgd2hpY2hcXG4gKiAgIGNhbiBiZSB1c2VmdWwgdG8gdW5kZXJzdGFuZCBob3cgdGhlIGNvZGUgaXMgZXhlY3V0ZWQuXFxuICogXFxuICogWW91IGNhbiBjaGFuZ2UgdGhlIHdheSB0aGF0IHRoZSBKYXZhU2NyaXB0IGNvZGUgaXMgaW50ZXJwcmV0ZWRcXG4gKiBieSBjbGlja2luZyBcXFwiSmF2YVNjcmlwdFxcXCIgaW4gdGhlIGhlYWRlciBhbmQgc2VsZWN0aW5nIGRpZmZlcmVudFxcbiAqIG9wdGlvbnMuXFxuICovXFxuXFxuaW1wb3J0IGpzIGZyb20gXFxcIkBlc2xpbnQvanNcXFwiO1xcblxcbmZ1bmN0aW9uIGdldENvbmZpZygpIHtcXG4gICAgcmV0dXJuIHtcXG4gICAgICAgIHJ1bGVzOiB7XFxuICAgICAgICAgICAgXFxcInByZWZlci1jb25zdFxcXCI6IFxcXCJ3YXJuXFxcIlxcbiAgICAgICAgfVxcbiAgICB9O1xcbn1cXG5cXG5leHBvcnQgZGVmYXVsdCBbXFxuICAgIC4uLmpzLmNvbmZpZ3MucmVjb21tZW5kZWQsXFxuICAgIGdldENvbmZpZygpXFxuXTtcIixcImpzb25cIjpcIntcXG5mb286IFxcXCJiYXJcXFwiXFxufVwiLFwibWFya2Rvd25cIjpcIiMjIyBmb2%2BgIyMjXFxuXFxuXCIsXCJjc3NcIjpcIi8qKlxcbiAqIFR5cGUgb3IgcGFzdGUgc29tZSBDU1MgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxuICogdGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG4gKlxcbiAqIFRoZSB0YWJzIGFyZTpcXG4gKlxcbiAqIC0gQVNUIC0gVGhlIEFic3RyYWN0IFN5bnRheCBUcmVlIG9mIHRoZSBjb2RlLCB3aGljaCBjYW5cXG4gKiAgIGJlIHVzZWZ1bCB0byB1bmRlcnN0YW5kIHRoZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUuIFlvdVxcbiAqICAgY2FuIHZpZXcgdGhpcyBzdHJ1Y3R1cmUgYXMgSlNPTiBvciBpbiBhIHRyZWUgZm9ybWF0LlxcbiAqXFxuICogWW91IGNhbiBjaGFuZ2UgdGhlIHdheSB0aGF0IHRoZSBDU1MgY29kZSBpcyBpbnRlcnByZXRlZFxcbiAqIGJ5IGNsaWNraW5nIFxcXCJDU1NcXFwiIGluIHRoZSBoZWFkZXIgYW5kIHNlbGVjdGluZyBkaWZmZXJlbnRcXG4gKiBvcHRpb25zLlxcbiAqL1xcblxcbkBpbXBvcnQgdXJsKCdodHRwczovL2ZvbnRzLmdvb2dsZWFwaXMuY29tL2NzczI%2FZmFtaWx5PVJvYm90bzp3Z2h0QDQwMDs3MDAmZGlzcGxheT1zd2FwJyk7XFxuXFxuYm9keSB7XFxuXFx0Zm9udC1mYW1pbHk6IHNhbnMtc2VyaWY7XFxufVxcblxcbmgxIHtcXG5cXHRjb2xvcjogIzMzMztcXG59XFxuXFxucCB7XFxuXFx0bWFyZ2luOiAxZW0gMDtcXG59XCIsXCJodG1sXCI6XCI8IURPQ1RZUEUgaHRtbD5cXG48IS0tXFxuVHlwZSBvciBwYXN0ZSBzb21lIEhUTUwgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XFxudGhlIHN0YXRpYyBhbmFseXNpcyB0aGF0IEVTTGludCBjYW4gZG8gZm9yIHlvdS5cXG5cXG5UaGUgdGFicyBhcmU6XFxuXFxuLSBBU1QgLSBUaGUgQWJzdHJhY3QgU3ludGF4IFRyZWUgb2YgdGhlIGNvZGUsIHdoaWNoIGNhblxcbmJlIHVzZWZ1bCB0byB1bmRlcnN0YW5kIHRoZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUuIFlvdVxcbmNhbiB2aWV3IHRoaXMgc3RydWN0dXJlIGFzIEpTT04gb3IgaW4gYSB0cmVlIGZvcm1hdC5cXG4tLT5cXG5cXG48aHRtbCBsYW5nPVxcXCJlblxcXCI%2BXFxuICAgIDxoZWFkPlxcbiAgICAgICAgPG1ldGEgY2hhcnNldD1cXFwiVVRGLThcXFwiPlxcbiAgICAgICAgPHRpdGxlPkhUTUw8L3RpdGxlPlxcbiAgICA8L2hlYWQ%2BXFxuICAgIDxib2R5PlxcbiAgICAgICAgPHA%2BVGV4dDwvcD5cXG4gICAgPC9ib2R5PlxcbjwvaHRtbD5cIn0sXCJsYW5ndWFnZVwiOlwibWFya2Rvd25cIixcImpzT3B0aW9uc1wiOntcInBhcnNlclwiOlwiZXNwcmVlXCIsXCJzb3VyY2VUeXBlXCI6XCJtb2R1bGVcIixcImVzVmVyc2lvblwiOlwibGF0ZXN0XCIsXCJpc0pTWFwiOnRydWV9LFwianNvbk9wdGlvbnNcIjp7XCJqc29uTW9kZVwiOlwianNvbjVcIixcImFsbG93VHJhaWxpbmdDb21tYXNcIjpmYWxzZX0sXCJjc3NPcHRpb25zXCI6e1wiY3NzTW9kZVwiOlwiY3NzXCIsXCJ0b2xlcmFudFwiOmZhbHNlfSxcIm1hcmtkb3duT3B0aW9uc1wiOntcIm1hcmtkb3duTW9kZVwiOlwiZ2ZtXCIsXCJtYXJrZG93bkZyb250bWF0dGVyXCI6XCJvZmZcIn0sXCJ3cmFwXCI6dHJ1ZSxcInZpZXdNb2Rlc1wiOntcImFzdFZpZXdcIjpcInRyZWVcIixcInNjb3BlVmlld1wiOlwiZmxhdFwiLFwicGF0aFZpZXdcIjpcImdyYXBoXCJ9LFwicGF0aEluZGV4XCI6e1wiaW5kZXhcIjowLFwiaW5kZXhlc1wiOjJ9LFwiZXNxdWVyeVNlbGVjdG9yXCI6e1wic2VsZWN0b3JcIjpcIlwifX0sXCJ2ZXJzaW9uXCI6MH0i)

![image](https://github.com/user-attachments/assets/2594389b-085d-457c-9b07-c5e719ed3230)

Also, Here's CommonMark specification:

https://spec.commonmark.org/0.31.2/#example-63

![image](https://github.com/user-attachments/assets/81254998-86ef-4427-9eea-d09e0ca3da8d)

#### What changes did you make? (Give an overview)

I’ve updated the `no-duplicate-headings` rule to align with the CommonMark specification.

#### Related Issues

Ref: https://github.com/eslint/markdown/pull/421

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
