### PR TITLE
docs: replace AST-related description from no-duplicate-definitions

### DIFF
--- a/docs/rules/no-duplicate-definitions.md
+++ b/docs/rules/no-duplicate-definitions.md
@@ -17,7 +17,7 @@ Please note that this rule does not report definition-style comments. For exampl
 
 > [!IMPORTANT] <!-- eslint-disable-line -- This should be fixed in https://github.com/eslint/markdown/issues/294 -->
 >
-> The `FootnoteDefinition` node is detected only when using `language` mode [`markdown/gfm`](/README.md#languages).
+> The footnotes are only supported when using `language` mode [`markdown/gfm`](/README.md#languages).
 
 This rule warns when `Definition` and `FootnoteDefinition` type identifiers are defined multiple times. Please note that this rule is **case-insensitive**, meaning `earth` and `Earth` are treated as the same identifier.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello, 

This PR is follow-up to https://github.com/eslint/markdown/pull/425#discussion_r2161959198.

I've removed AST-related description from `no-duplicate-definitions` in favor of a more user-friendly description.

#### What changes did you make? (Give an overview)

I've removed AST-related description from `no-duplicate-definitions` in favor of a more user-friendly description.

#### Related Issues

Ref: https://github.com/eslint/markdown/pull/425#discussion_r2161959198

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
