### PR TITLE
fix: skip HTML nodes in heading slugs for no-missing-link-fragments

### DIFF
--- a/docs/rules/no-missing-link-fragments.md
+++ b/docs/rules/no-missing-link-fragments.md
@@ -54,6 +54,10 @@ Examples of **correct** code for this rule:
 [Link to top of page](#top)
 
 [Link](#L2)
+
+# <span class="icon-star"></span> Starred Projects
+
+[Link to starred projects](#-starred-projects)
 ```
 
 ## Options

--- a/src/rules/no-missing-link-fragments.js
+++ b/src/rules/no-missing-link-fragments.js
@@ -47,6 +47,9 @@ function isGitHubLineReference(fragment) {
  * @returns {string} The extracted text
  */
 function extractText(node) {
+	if (node.type === "html") {
+		return "";
+	}
 	if ("value" in node) {
 		return /** @type {string} */ (node.value);
 	}

--- a/tests/rules/no-missing-link-fragments.test.js
+++ b/tests/rules/no-missing-link-fragments.test.js
@@ -228,6 +228,37 @@ ruleTester.run("no-missing-link-fragments", rule, {
 		# foo_
 		[Link](#foo_)
 		`,
+		dedent`
+		# <picture></picture> Heading Name
+		[Link](#-heading-name)
+		`,
+		dedent`
+		# Heading Name <picture></picture>
+		[Link](#heading-name-)
+		`,
+		dedent`
+		# Heading <picture></picture> Name
+		[Link](#heading--name)
+		`,
+		dedent`
+		# <span>Text</span> Heading Name
+		[Link](#text-heading-name)
+		`,
+		dedent`
+		# ![alt text](img.png) Heading Name
+		[Link](#-heading-name)
+		`,
+		dedent`
+		# Heading Name ![alt text](img.png)
+		[Link](#heading-name-)
+		`,
+		{
+			code: dedent`
+			# <picture></picture> Heading Name
+			[Link](#-HEADING-NAME)
+			`,
+			options: [{ ignoreCase: true }],
+		},
 	],
 
 	invalid: [
@@ -477,6 +508,38 @@ ruleTester.run("no-missing-link-fragments", rule, {
 					column: 1,
 					endLine: 15,
 					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: dedent`
+			# <picture></picture> Heading Name
+			[Link](#heading-name)
+			`,
+			errors: [
+				{
+					messageId: "invalidFragment",
+					data: { fragment: "heading-name" },
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: dedent`
+			# ![alt text](img.png) Heading Name
+			[Link](#heading-name)
+			`,
+			errors: [
+				{
+					messageId: "invalidFragment",
+					data: { fragment: "heading-name" },
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 22,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes the handling of heading slugs in the no-missing-link-fragments rule to ensure that HTML nodes are excluded from the generated anchor fragments.

#### What changes did you make? (Give an overview)

Updated the heading text extraction logic in no-missing-link-fragments to skip HTML nodes when generating slugs for headings.

#### Related Issues

Fixes #439

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
