### PR TITLE
fix!: move certain types to import them from `@eslint/markdown/types`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,7 @@ import rules from "./build/rules.js";
 
 /**
  * @import { Linter } from "eslint";
- * @import * as Types from "./types.js";
  * @typedef {Linter.RulesRecord} RulesRecord
- * @typedef {Types.MarkdownRuleDefinition} RuleModule
  */
 
 //-----------------------------------------------------------------------------

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,7 +1,4 @@
-import markdown, {
-	MarkdownSourceCode,
-	type RuleModule,
-} from "@eslint/markdown";
+import markdown, { MarkdownSourceCode } from "@eslint/markdown";
 import type { SourceLocation, SourceRange } from "@eslint/core";
 import type {
 	MarkdownRuleDefinition,
@@ -80,7 +77,7 @@ typeof processorPlugins satisfies {};
 	null as AssertAllNamesIn<RecommendedRuleName, RuleName>;
 }
 
-(): RuleModule => ({
+(): MarkdownRuleDefinition => ({
 	create({ sourceCode }): MarkdownRuleVisitor {
 		sourceCode satisfies MarkdownSourceCode;
 		sourceCode.ast satisfies Root;
@@ -175,16 +172,11 @@ typeof processorPlugins satisfies {};
 	},
 });
 
-// All options optional - MarkdownRuleDefinition, MarkdownRuleDefinition<{}> and RuleModule
+// All options optional - MarkdownRuleDefinition and MarkdownRuleDefinition<{}>
 // should be the same type.
-(
-	rule1: MarkdownRuleDefinition,
-	rule2: MarkdownRuleDefinition<{}>,
-	rule3: RuleModule,
-) => {
-	rule1 satisfies typeof rule2 satisfies typeof rule3;
-	rule2 satisfies typeof rule1 satisfies typeof rule3;
-	rule3 satisfies typeof rule1 satisfies typeof rule2;
+(rule1: MarkdownRuleDefinition, rule2: MarkdownRuleDefinition<{}>) => {
+	rule1 satisfies typeof rule2;
+	rule2 satisfies typeof rule1;
 };
 
 // Type restrictions should be enforced


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

<!-- eslint-disable-next-line markdown/no-missing-label-refs -->
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello. 

The purpose of this PR is to align the type import path with the JSON and CSS plugins.

This is a **breaking change**, and it was discussed in https://github.com/eslint/markdown/pull/367#discussion_r2161724631 Also, it serves as a prerequisite for https://github.com/eslint/markdown/pull/367.

Currently, we import `*RuleDefinition` and `*RuleVisitor` types directly from the main entry point, like `@eslint/markdown`.
This PR moves those types under `@eslint/markdown/types`.

Here are some references:

* https://github.com/eslint/json/blob/main/tests/types/types.test.ts#L3-L7
* https://github.com/eslint/css/blob/main/tests/types/types.test.ts#L55

Looking at the `dist` folders of the JSON and CSS plugins, they do **not** export `*RuleDefinition` and `*RuleVisitor` types from their main entries (e.g., `@eslint/json`, `@eslint/css`).
Instead, they export those types from `@eslint/json/types` and `@eslint/css/types`, respectively.

---

One thing I'm unsure about is how we should handle the `RuleModule` type in the Markdown plugin.
I've left a detailed comment regarding this concern.

#### What changes did you make? (Give an overview)

#### Related Issues

Ref: https://github.com/eslint/markdown/pull/367#discussion_r2161724631

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
