### PR TITLE
docs: remove `CONTRIBUTING.md` in favor of centralized template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,0 @@
-# Contributing Code
-
-Please sign the ESLint [Contributor License Agreement](https://eslint.org/cla)
-
-## Full Documentation
-
-Our full contribution guidelines can be found at:
-http://eslint.org/docs/developer-guide/contributing/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

This PR is follow-up to https://github.com/eslint/js/pull/666.

---

In this PR, I have removed `CONTRIBUTING.md` in favor of using the centralized template.

Since the PR to create the centralized `CONTRIBUTING.md` has been merged into the `.github` repository (ref: https://github.com/eslint/.github/pull/8), the contributing template can now be managed from there.

After reviewing the template in this repository, I noticed that it’s a simplified version of the centralized one. For this reason, I’d like to suggest removing it from here and maintaining the template in the `.github` repository instead.

Maintaining a separate contributing template in this repository would override the template in the `.github` repository, which would prevent us from fully benefiting from the centralized template.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
