### PR TITLE
fix: remove unused types from `types.ts`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,6 @@ import type {
 	// Extensions (front matter)
 	Yaml,
 } from "mdast";
-import type { Linter } from "eslint";
 import type {
 	LanguageOptions,
 	LanguageContext,
@@ -77,10 +76,6 @@ export interface BlockBase {
 export interface Block extends Node, BlockBase {
 	meta: string | null;
 }
-
-export type Message = Linter.LintMessage;
-
-export type RuleType = "problem" | "suggestion" | "layout";
 
 /**
  * Markdown TOML.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

While reviewing the `types.ts` file, I noticed that `Message` and `RuleType` are not used anywhere.

It seems these two types were not removed during the refactor.

I think removing unused types would be helpful, but I'm not sure if this should be considered a breaking change, since users can import types from `types.ts` via `@eslint/markdown/types`, and version 7 was just released.

On the other hand, since these types were likely included by mistake during a refactor, it might make sense to treat their removal as a fix.

I'd be interested to hear team's thoughts on how we should handle these unused types.

(Personally, I don't think these two types play an important role in the markdown plugins.)

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
