### PR TITLE
fix: case-insensitive attribute checks in `no-missing-link-fragment`

### DIFF
--- a/src/rules/no-missing-link-fragments.js
+++ b/src/rules/no-missing-link-fragments.js
@@ -28,7 +28,7 @@ import GithubSlugger from "github-slugger";
 const githubLineReferencePattern = /^L\d+(?:C\d+)?(?:-L\d+(?:C\d+)?)?$/u;
 const customHeadingIdPattern = /\{#([^}\s]+)\}\s*$/u;
 const htmlCommentPattern = /<!--[\s\S]*?-->/gu;
-const htmlIdNamePattern = /<(?:[^>]+)\s+(?:id|name)=["']([^"']+)["']/gu;
+const htmlIdNamePattern = /<(?:[^>]+)\s+(?:id|name)=["']([^"']+)["']/giu;
 
 /**
  * Checks if the fragment is a valid GitHub line reference

--- a/tests/rules/no-missing-link-fragments.test.js
+++ b/tests/rules/no-missing-link-fragments.test.js
@@ -43,9 +43,33 @@ ruleTester.run("no-missing-link-fragments", rule, {
 		[Link](#bookmark)
 		`,
 
+		// HTML anchor tags case-insensitive
+		dedent`
+		<a ID="bookmark"></a>
+		[Link](#bookmark)
+		`,
+
+		// HTML anchor tags case-insensitive
+		dedent`
+		<a Id="bookmark"></a>
+		[Link](#bookmark)
+		`,
+
 		// HTML name attribute
 		dedent`
 		<a name="old-style"></a>
+		[Link](#old-style)
+		`,
+
+		// HTML name attribute case-insensitive
+		dedent`
+		<a NAME="old-style"></a>
+		[Link](#old-style)
+		`,
+
+		// HTML name attribute case-insensitive
+		dedent`
+		<a NaMe="old-style"></a>
 		[Link](#old-style)
 		`,
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I've fixed case-insensitive attribute checks in `no-missing-link-fragment`.

According to the HTML specification, HTML attributes should be case-insensitive.

https://html.spec.whatwg.org/multipage/syntax.html#writing

<img width="1270" height="92" alt="image" src="https://github.com/user-attachments/assets/c6930b4c-f510-4207-a4db-71a3a90fd0b1" />

#### What changes did you make? (Give an overview)

I've fixed case-insensitive checks for attributes in `no-missing-link-fragment` and added some test cases.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
