### PR TITLE
refactor: use `CustomRuleDefinitionType` in `MarkdownRuleDefinition`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "@eslint/core": "^0.14.0",
+    "@eslint/core": "^0.15.0",
     "@eslint/plugin-kit": "^0.3.1",
     "github-slugger": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,10 @@ import type {
 	Yaml,
 } from "mdast";
 import type {
-	LanguageOptions,
+	CustomRuleDefinitionType,
+	CustomRuleTypeDefinitions,
 	LanguageContext,
-	RuleDefinition,
+	LanguageOptions,
 	RuleVisitor,
 } from "@eslint/core";
 import type { MarkdownSourceCode } from "./index.js";
@@ -170,25 +171,16 @@ export interface MarkdownRuleVisitor
 			}
 		> {}
 
-export type MarkdownRuleDefinitionTypeOptions = {
-	RuleOptions: unknown[];
-	MessageIds: string;
-	ExtRuleDocs: Record<string, unknown>;
-};
+export type MarkdownRuleDefinitionTypeOptions = CustomRuleTypeDefinitions;
 
 export type MarkdownRuleDefinition<
 	Options extends Partial<MarkdownRuleDefinitionTypeOptions> = {},
-> = RuleDefinition<
-	// Language specific type options (non-configurable)
+> = CustomRuleDefinitionType<
 	{
 		LangOptions: MarkdownLanguageOptions;
 		Code: MarkdownSourceCode;
 		Visitor: MarkdownRuleVisitor;
 		Node: Node;
-	} & Required<
-		// Rule specific type options (custom)
-		Options &
-			// Rule specific type options (defaults)
-			Omit<MarkdownRuleDefinitionTypeOptions, keyof Options>
-	>
+	},
+	Options
 >;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Simplify type definitions.

#### What changes did you make? (Give an overview)

* Refactored the type definition of `MarkdownRuleDefinition` using the core [`CustomRuleDefinitionType`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L598-L631) type.
* Redefined `MarkdownRuleDefinitionTypeOptions` as an alias for the core [`CustomRuleTypeDefinitions`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L589-L596) type.
* Also upgraded `@eslint/core` to v0.15.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/rewrite#177

Related PRs: eslint/eslint#19949, eslint/css#203, eslint/json#121

#### Is there anything you'd like reviewers to focus on?
