### PR TITLE
refactor: add missing type annotations to variables

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -205,7 +205,9 @@ export class MarkdownSourceCode extends TextSourceCodeBase {
 	 *      that ESLint needs to further process the directives.
 	 */
 	getDisableDirectives() {
+		/** @type {Array<FileProblem>} */
 		const problems = [];
+		/** @type {Array<Directive>} */
 		const directives = [];
 
 		this.getInlineConfigNodes().forEach(comment => {
@@ -263,7 +265,9 @@ export class MarkdownSourceCode extends TextSourceCodeBase {
 	 *      that ESLint needs to further process the rule configurations.
 	 */
 	applyInlineConfig() {
+		/** @type {Array<FileProblem>} */
 		const problems = [];
+		/** @type {Array<{config:{rules:RulesConfig},loc:SourceLocation}>} */
 		const configs = [];
 
 		this.getInlineConfigNodes().forEach(comment => {

--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -125,6 +125,8 @@ export default {
 
 	create(context) {
 		const { sourceCode } = context;
+
+		/** @type {Array<{label:string,position:Position}>} */
 		let allMissingReferences = [];
 
 		return {

--- a/src/rules/no-missing-link-fragments.js
+++ b/src/rules/no-missing-link-fragments.js
@@ -14,7 +14,7 @@ import GithubSlugger from "github-slugger";
 //-----------------------------------------------------------------------------
 
 /**
- * @import { Node } from "mdast";
+ * @import { Node, Link } from "mdast";
  * @import { MarkdownRuleDefinition } from "../types.js";
  * @typedef {"invalidFragment"} NoMissingLinkFragmentsMessageIds
  * @typedef {[{ ignoreCase?: boolean; allowPattern?: string }]} NoMissingLinkFragmentsOptions
@@ -110,6 +110,8 @@ export default {
 
 		const fragmentIds = new Set(["top"]);
 		const slugger = new GithubSlugger();
+
+		/** @type {Array<{node: Link, fragment: string}>} */
 		const linkNodes = [];
 
 		return {

--- a/src/rules/no-reversed-media-syntax.js
+++ b/src/rules/no-reversed-media-syntax.js
@@ -47,6 +47,7 @@ function isInCodeSpan(matchIndex, codeSpans) {
  * @returns {Array<{startOffset: number, endOffset: number}>} Array of code span positions
  */
 function findCodeSpans(node) {
+	/** @type {Array<{startOffset: number, endOffset: number}>} */
 	const codeSpans = [];
 
 	/**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I've added missing type annotations to variables.

Adding type annotations helps improve type safety, and I noticed that some variables were missing them, so I went ahead and added the necessary annotations.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
