### PR TITLE
fix: fenced-code-language highlights only relevant parts

### DIFF
--- a/src/rules/fenced-code-language.js
+++ b/src/rules/fenced-code-language.js
@@ -81,7 +81,16 @@ export default {
 					}
 
 					context.report({
-						loc: node.position,
+						loc: {
+							start: node.position.start,
+							end: {
+								line: node.position.start.line,
+								column:
+									sourceCode.lines[
+										node.position.start.line - 1
+									].length + 1,
+							},
+						},
 						messageId: "missingLanguage",
 					});
 
@@ -90,7 +99,16 @@ export default {
 
 				if (required.size && !required.has(node.lang)) {
 					context.report({
-						loc: node.position,
+						loc: {
+							start: node.position.start,
+							end: {
+								line: node.position.start.line,
+								column:
+									sourceCode.lines[
+										node.position.start.line - 1
+									].length + 1,
+							},
+						},
 						messageId: "disallowedLanguage",
 						data: {
 							lang: node.lang,

--- a/src/rules/fenced-code-language.js
+++ b/src/rules/fenced-code-language.js
@@ -98,15 +98,19 @@ export default {
 				}
 
 				if (required.size && !required.has(node.lang)) {
+					const lineText =
+						sourceCode.lines[node.position.start.line - 1];
+					const langIndex = lineText.indexOf(node.lang);
+
 					context.report({
 						loc: {
 							start: node.position.start,
 							end: {
 								line: node.position.start.line,
 								column:
-									sourceCode.lines[
-										node.position.start.line - 1
-									].length + 1,
+									node.position.start.column +
+									langIndex +
+									node.lang.length,
 							},
 						},
 						messageId: "disallowedLanguage",

--- a/tests/rules/fenced-code-language.test.js
+++ b/tests/rules/fenced-code-language.test.js
@@ -139,10 +139,58 @@ console.log("Hello, world!");
 			],
 		},
 		{
+			code: `\`\`\`\`javascript
+console.log("Hello, world!");
+\`\`\`\``,
+			options: [{ required: ["js"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "javascript" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
+		{
 			code: `\`\`\`js
 console.log("Hello, world!");
 \`\`\``,
 			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 6,
+				},
+			],
+		},
+		{
+			code: `\`\`\` js
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: `\`\`\`js foo
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["foo"] }],
 			errors: [
 				{
 					messageId: "disallowedLanguage",
@@ -171,10 +219,58 @@ console.log("Hello, world!");
 			],
 		},
 		{
+			code: `~~~~javascript
+console.log("Hello, world!");
+~~~~`,
+			options: [{ required: ["js"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "javascript" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
+		{
 			code: `~~~js
 console.log("Hello, world!");
 ~~~`,
 			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 6,
+				},
+			],
+		},
+		{
+			code: `~~~ js
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: `~~~js foo
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["foo"] }],
 			errors: [
 				{
 					messageId: "disallowedLanguage",

--- a/tests/rules/fenced-code-language.test.js
+++ b/tests/rules/fenced-code-language.test.js
@@ -50,6 +50,48 @@ console.log("Hello, world!");
 \`\`\``,
 			options: [{ required: ["js"] }],
 		},
+		{
+			code: `\`\`\`js foo
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["js"] }],
+		},
+		{
+			code: `\`\`\` js
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["js"] }],
+		},
+		{
+			code: `\`\`\`JS
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["JS"] }],
+		},
+		{
+			code: `~~~js
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["js"] }],
+		},
+		{
+			code: `~~~js foo
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["js"] }],
+		},
+		{
+			code: `~~~ js
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["js"] }],
+		},
+		{
+			code: `~~~JS
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["JS"] }],
+		},
 	],
 	invalid: [
 		{
@@ -61,7 +103,7 @@ console.log("Hello, world!");
 					messageId: "missingLanguage",
 					line: 1,
 					column: 1,
-					endLine: 3,
+					endLine: 1,
 					endColumn: 4,
 				},
 			],
@@ -75,7 +117,7 @@ console.log("Hello, world!");
 					messageId: "missingLanguage",
 					line: 1,
 					column: 1,
-					endLine: 3,
+					endLine: 1,
 					endColumn: 4,
 				},
 			],
@@ -91,8 +133,56 @@ console.log("Hello, world!");
 					data: { lang: "javascript" },
 					line: 1,
 					column: 1,
-					endLine: 3,
-					endColumn: 4,
+					endLine: 1,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: `\`\`\`js
+console.log("Hello, world!");
+\`\`\``,
+			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 6,
+				},
+			],
+		},
+		{
+			code: `~~~javascript
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["js"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "javascript" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: `~~~js
+console.log("Hello, world!");
+~~~`,
+			options: [{ required: ["JS"] }],
+			errors: [
+				{
+					messageId: "disallowedLanguage",
+					data: { lang: "js" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 6,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request aims to enhance the clarity and precision of error reporting for the fenced-code-language rule. Previously, rule violations would highlight the entire code block, making it difficult to pinpoint the exact issue. This change ensures that only the relevant parts of the code are highlighted, improving the developer experience.

#### What changes did you make? (Give an overview)

I've modified the fenced-code-language rule to provide more targeted highlighting for violations:

- For missing language errors, only the opening fences (e.g., ```) of the code block are now highlighted.
- For disallowed language errors, it will highlight the opening fence and the specified language.

#### Related Issues

Fixes #476

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
