### PR TITLE
fix: add CR to the line ending pattern

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -167,7 +167,7 @@ export class MarkdownSourceCode extends TextSourceCodeBase {
 	 * @param {Root} options.ast The root AST node.
 	 */
 	constructor({ text, ast }) {
-		super({ ast, text });
+		super({ ast, text, lineEndingPattern: /\n|\r|\r\n/u });
 		this.ast = ast;
 
 		// need to traverse the source code to get the inline config nodes


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

Working in progress.

According to the Markdown specification, LF, CR, and CRLF can all be used for line endings.

https://spec.commonmark.org/0.31.2/#line-ending

<img width="877" height="61" alt="Image" src="https://github.com/user-attachments/assets/62092bda-0c9d-4051-b495-cbbee06caa91" />

## What changes did you make? (Give an overview)

## Related Issues

Ref: https://github.com/eslint/markdown/pull/491#discussion_r2251033615

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?
