### PR TITLE
ci: centralize `add-to-triage.yml`

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -1,18 +1,19 @@
-name: Add to Triage
+name: add-to-triage
 
 on:
     issues:
         types:
             - opened
+            - reopened
+            - transferred
+
+    pull_request:
+        types:
+            - opened
+            - reopened
 
 jobs:
-    add-to-project:
-        name: Add issue to project
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/add-to-project@v0.4.0
-              with:
-                  project-url: https://github.com/orgs/eslint/projects/3
-                  github-token: ${{ secrets.PROJECT_BOT_TOKEN }}
-                  labeled: "triage:no"
-                  label-operator: NOT
+    add-to-triage:
+        uses: eslint/workflows/.github/workflows/add-to-triage.yml@main
+        secrets:
+            PROJECT_BOT_TOKEN: ${{ secrets.PROJECT_BOT_TOKEN }}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

This PR is part of the process to centralize workflows. In this PR, I've added the `add-to-triage.yml` workflow, which uses the centralized workflow.

You can find more details about this workflow in https://github.com/eslint/workflows/issues/4 and https://github.com/eslint/workflows/pull/7.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
