### PR TITLE
refactor: simplify `no-reversed-media-syntax` with ESQuery selector

### DIFF
--- a/src/rules/no-reversed-media-syntax.js
+++ b/src/rules/no-reversed-media-syntax.js
@@ -14,7 +14,8 @@ import { findOffsets } from "../util.js";
 //-----------------------------------------------------------------------------
 
 /**
- * @import { Node, Heading, Paragraph, TableCell } from "mdast";
+ * @import { SourceRange } from "@eslint/core"
+ * @import { Heading, Paragraph, TableCell } from "mdast";
  * @import { MarkdownRuleDefinition } from "../types.js";
  * @typedef {"reversedSyntax"} NoReversedMediaSyntaxMessageIds
  * @typedef {[]} NoReversedMediaSyntaxOptions
@@ -32,13 +33,12 @@ const reversedPattern =
 /**
  * Checks if a match is within any skip range
  * @param {number} matchIndex The index of the match
- * @param {Array<{startOffset: number, endOffset: number}>} skipRanges The skip ranges
+ * @param {Array<SourceRange>} skipRanges The skip ranges
  * @returns {boolean} True if the match is within a skip range
  */
 function isInSkipRange(matchIndex, skipRanges) {
 	return skipRanges.some(
-		range =>
-			range.startOffset <= matchIndex && matchIndex < range.endOffset,
+		range => range[0] <= matchIndex && matchIndex < range[1],
 	);
 }
 
@@ -66,7 +66,9 @@ export default {
 	},
 
 	create(context) {
-		/** @type {Array<{startOffset: number, endOffset: number}>} */
+		const { sourceCode } = context;
+
+		/** @type {Array<SourceRange>} */
 		let skipRanges = [];
 
 		/**
@@ -75,7 +77,7 @@ export default {
 		 * @returns {void} Reports any reversed syntax found.
 		 */
 		function findReversedMediaSyntax(node) {
-			const text = context.sourceCode.getText(node);
+			const text = sourceCode.getText(node);
 			let match;
 
 			while ((match = reversedPattern.exec(text)) !== null) {
@@ -142,10 +144,7 @@ export default {
 
 		return {
 			"heading html,inlineCode"(node) {
-				skipRanges.push({
-					startOffset: node.position.start.offset,
-					endOffset: node.position.end.offset,
-				});
+				skipRanges.push(sourceCode.getRange(node));
 			},
 
 			"heading:exit"(node) {
@@ -154,10 +153,7 @@ export default {
 			},
 
 			"paragraph html,inlineCode"(node) {
-				skipRanges.push({
-					startOffset: node.position.start.offset,
-					endOffset: node.position.end.offset,
-				});
+				skipRanges.push(sourceCode.getRange(node));
 			},
 
 			"paragraph:exit"(node) {
@@ -166,10 +162,7 @@ export default {
 			},
 
 			"tableCell html,inlineCode"(node) {
-				skipRanges.push({
-					startOffset: node.position.start.offset,
-					endOffset: node.position.end.offset,
-				});
+				skipRanges.push(sourceCode.getRange(node));
 			},
 
 			"tableCell:exit"(node) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

In this PR, I've refactored the `no-reversed-media-syntax` rule, thanks to https://github.com/eslint/markdown/pull/469#pullrequestreview-3043363252.

Previously, we used a separate traversing logic with the `findSkipRanges` helper function. This was somewhat redundant, since ESLint already traverses the AST for us, resulting in duplicate traversing.

I've updated the code to use an ESQuery selector instead, which simplifies the traversing logic.

I've also used the `getRange` method to make the rule more native and switched to the `SourceRange` data structure for better consistency.

#### What changes did you make? (Give an overview)

In this PR, I've refactored the `no-reversed-media-syntax` rule, thanks to https://github.com/eslint/markdown/pull/469#pullrequestreview-3043363252.

#### Related Issues

Ref: https://github.com/eslint/markdown/pull/469#pullrequestreview-3043363252

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
