### PR TITLE
fix: allow any type for `meta.docs.recommended` in custom rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,12 +86,12 @@
     "lint-staged": "^15.2.9",
     "mocha": "^11.6.0",
     "prettier": "^3.3.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "@eslint/core": "^0.15.1",
-    "@eslint/plugin-kit": "^0.3.4",
+    "@eslint/core": "^0.15.2",
+    "@eslint/plugin-kit": "^0.3.5",
     "github-slugger": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-frontmatter": "^2.0.1",

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -289,3 +289,18 @@ typeof processorPlugins satisfies {};
 		return {};
 	},
 });
+
+// `meta.docs.recommended` can be any type
+(): MarkdownRuleDefinition => ({
+	create() {
+		return {};
+	},
+	meta: {
+		docs: {
+			recommended: {
+				severity: "warn",
+				options: ["never"],
+			},
+		},
+	},
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

This PR is follow-up to https://github.com/eslint/eslint/pull/19995.

You can find more details about this change in https://github.com/eslint/rewrite/issues/234.

#### What changes did you make? (Give an overview)

- Updated `@eslint/core` to allow arbitrary types for `meta.docs.recommended` in custom rules.
- Upgraded other dependencies to the latest versions.
- Updated type tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
