### PR TITLE
test: add tests for plugin rules and recommended rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "npm run build:rules && tsc && npm run build:update-rules-docs",
     "build:readme": "node tools/update-readme.js",
     "prepare": "npm run build",
-    "test": "c8 mocha \"tests/**/*.test.js\" --timeout 30000",
+    "test": "mocha \"tests/**/*.test.js\" --timeout 30000",
     "test:coverage": "c8 npm test",
     "test:jsr": "npx jsr@latest publish --dry-run",
     "test:types": "tsc -p tests/types/tsconfig.json"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add unit tests

#### What changes did you make? (Give an overview)

Added a unit test to verify that:
* The plugin exports all rules in `src/rules`.
* The recommended config configures exactly the rules marked as recommended. `@eslint/css` and `@eslint/json` include this test in `tests/package/exports.js`.

These tests ensure that the autogenerated files in `src/build` work as expected.

I also updated the npm `test` script to not use c8 for code coverage. We don't need to run c8 in GitHub Actions because we don't enforce minimum thresholds in this repo, like we do in the main repo (see https://github.com/eslint/eslint/blob/v9.33.0/Makefile.js#L596). c8 coverage can be collected locally by running the `test:coverage` script.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

eslint/css#236, eslint/json#134

#### Is there anything you'd like reviewers to focus on?

