### PR TITLE
feat: Expose identifiers in messages for no-duplicate-definitions

### DIFF
--- a/src/rules/no-duplicate-definitions.js
+++ b/src/rules/no-duplicate-definitions.js
@@ -36,9 +36,10 @@ export default {
 		},
 
 		messages: {
-			duplicateDefinition: "Unexpected duplicate definition found.",
+			duplicateDefinition:
+				"Unexpected duplicate definition `{{ identifier }}` found.",
 			duplicateFootnoteDefinition:
-				"Unexpected duplicate footnote definition found.",
+				"Unexpected duplicate footnote definition `{{ identifier }}` found.",
 		},
 
 		schema: [
@@ -100,6 +101,7 @@ export default {
 					context.report({
 						node,
 						messageId: "duplicateDefinition",
+						data: { identifier: node.identifier },
 					});
 				} else {
 					definitions.add(node.identifier);
@@ -115,6 +117,7 @@ export default {
 					context.report({
 						node,
 						messageId: "duplicateFootnoteDefinition",
+						data: { identifier: node.identifier },
 					});
 				} else {
 					footnoteDefinitions.add(node.identifier);

--- a/tests/rules/no-duplicate-definitions.test.js
+++ b/tests/rules/no-duplicate-definitions.test.js
@@ -185,6 +185,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -203,6 +204,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -210,6 +212,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 				},
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 4,
 					column: 1,
 					endLine: 4,
@@ -217,6 +220,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 				},
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 5,
 					column: 1,
 					endLine: 5,
@@ -233,6 +237,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -249,6 +254,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -272,6 +278,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -288,6 +295,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -306,6 +314,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -313,6 +322,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 				},
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 4,
 					column: 1,
 					endLine: 4,
@@ -320,6 +330,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 				},
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 5,
 					column: 1,
 					endLine: 5,
@@ -336,6 +347,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -359,6 +371,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateFootnoteDefinition",
+					data: { identifier: "mercury" },
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -384,6 +397,7 @@ ruleTester.run("no-duplicate-definitions", rule, {
 			errors: [
 				{
 					messageId: "duplicateDefinition",
+					data: { identifier: "mercury" },
 					line: 12,
 					column: 1,
 					endLine: 12,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
This pull request updates the no-duplicate-definitions rule to include the specific identifier in its error messages. This change helps developers quickly locate the specific definition causing the issue.

#### What changes did you make? (Give an overview)
- Updated the meta.messages of no-duplicate-definitions to include the {{ identifier }} placeholder.
- Updated the create function in the rule to pass the identifier through the data property in context.report().
- Updated the tests for the rule to verify that the identifier is correctly passed in invalid cases.
#### Related Issues
fixes #499 
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
