### PR TITLE
feat: expose identifiers in messages for no-empty-definitions

### DIFF
--- a/src/rules/no-empty-definitions.js
+++ b/src/rules/no-empty-definitions.js
@@ -52,9 +52,10 @@ export default {
 		},
 
 		messages: {
-			emptyDefinition: "Unexpected empty definition found.",
+			emptyDefinition:
+				"Unexpected empty definition `{{ identifier }}` found.",
 			emptyFootnoteDefinition:
-				"Unexpected empty footnote definition found.",
+				"Unexpected empty footnote definition `{{ identifier }}` found.",
 		},
 
 		schema: [
@@ -114,6 +115,7 @@ export default {
 					context.report({
 						loc: node.position,
 						messageId: "emptyDefinition",
+						data: { identifier: node.identifier },
 					});
 				}
 			},
@@ -132,6 +134,7 @@ export default {
 					context.report({
 						loc: node.position,
 						messageId: "emptyFootnoteDefinition",
+						data: { identifier: node.identifier },
 					});
 				}
 			},

--- a/tests/rules/no-empty-definitions.test.js
+++ b/tests/rules/no-empty-definitions.test.js
@@ -164,6 +164,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -176,6 +177,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -191,6 +193,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -198,6 +201,7 @@ ruleTester.run("no-empty-definitions", rule, {
 				},
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "bar" },
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -210,6 +214,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "note" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -222,6 +227,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "note" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -234,6 +240,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "note" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -246,6 +253,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "a" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -253,6 +261,7 @@ ruleTester.run("no-empty-definitions", rule, {
 				},
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "b" },
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -265,6 +274,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -272,6 +282,7 @@ ruleTester.run("no-empty-definitions", rule, {
 				},
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "note" },
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -285,6 +296,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -297,6 +309,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -311,6 +324,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 2,
@@ -325,6 +339,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 2,
@@ -337,6 +352,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -355,6 +371,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,
@@ -373,6 +390,7 @@ ruleTester.run("no-empty-definitions", rule, {
 			errors: [
 				{
 					messageId: "emptyFootnoteDefinition",
+					data: { identifier: "foo" },
 					line: 1,
 					column: 1,
 					endLine: 1,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Enhance the `no-empty-definitions` rule to include identifier data in its verification process,  
ensuring more informative and accurate error messages.

#### What changes did you make? (Give an overview)
- Updated `no-empty-definitions` rule logic to verify and expose identifier data.
- Added corresponding test cases in `no-empty-definitions.test.js` to cover new behavior.
- Ensured all existing tests pass.

#### Related Issues
refs #499 
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
