### PR TITLE
refactor: correct no-reversed-media-syntax selectors

### DIFF
--- a/src/rules/no-reversed-media-syntax.js
+++ b/src/rules/no-reversed-media-syntax.js
@@ -143,7 +143,9 @@ export default {
 		}
 
 		return {
-			"heading html,inlineCode"(node) {
+			":matches(heading, paragraph, tableCell) :matches(html, inlineCode)"(
+				node,
+			) {
 				skipRanges.push(sourceCode.getRange(node));
 			},
 
@@ -152,17 +154,9 @@ export default {
 				skipRanges = [];
 			},
 
-			"paragraph html,inlineCode"(node) {
-				skipRanges.push(sourceCode.getRange(node));
-			},
-
 			"paragraph:exit"(node) {
 				findReversedMediaSyntax(node);
 				skipRanges = [];
-			},
-
-			"tableCell html,inlineCode"(node) {
-				skipRanges.push(sourceCode.getRange(node));
 			},
 
 			"tableCell:exit"(node) {

--- a/src/rules/no-reversed-media-syntax.js
+++ b/src/rules/no-reversed-media-syntax.js
@@ -143,9 +143,7 @@ export default {
 		}
 
 		return {
-			":matches(heading, paragraph, tableCell) :matches(html, inlineCode)"(
-				node,
-			) {
+			"heading :matches(html, inlineCode)"(node) {
 				skipRanges.push(sourceCode.getRange(node));
 			},
 
@@ -154,9 +152,17 @@ export default {
 				skipRanges = [];
 			},
 
+			"paragraph :matches(html, inlineCode)"(node) {
+				skipRanges.push(sourceCode.getRange(node));
+			},
+
 			"paragraph:exit"(node) {
 				findReversedMediaSyntax(node);
 				skipRanges = [];
+			},
+
+			"tableCell :matches(html, inlineCode)"(node) {
+				skipRanges.push(sourceCode.getRange(node));
 			},
 
 			"tableCell:exit"(node) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### Example Code

```markdown
# Heading with `inline` code

Paragraph with `(label)[url]` reversed syntax.
```

#### Current Behavior

The selector syntax: `"heading html,inlineCode"` is interpreted as:
- html inside heading
- OR any `inlineCode` node anywhere in the document

While in practice this behaves as intended since `inlineCode` can only appear inside headings, paragraphs, or table cells, the syntax can be misread and is less explicit about its scoping.

#### Expected Behavior

Selectors should clearly indicate that both `html` and `inlineCode` are matched only when nested within the relevant container node.

#### What is the purpose of this pull request?

This PR fixes selector patterns to make their scope explicit and easier to read, replacing comma-separated selectors with `:matches()` expressions.

#### What changes did you make? (Give an overview)

- Replaced comma-separated selectors such as `"heading html,inlineCode"` with :matches() expressions like `"heading :matches(html, inlineCode)"`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
