### PR TITLE
feat: export types from main entry point

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,3 +135,4 @@ recommendedPlugins.markdown = processorPlugins.markdown = plugin;
 
 export default plugin;
 export { MarkdownSourceCode };
+export * from "./types.js";

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview Dummy file to enable exporting types from the main module.
+ * @author 루밀LuMir(lumirlumir)
+ */
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+export default {};

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,15 +1,16 @@
-import markdown, { MarkdownSourceCode } from "@eslint/markdown";
-import type { SourceLocation, SourceRange } from "@eslint/core";
+import markdown from "@eslint/markdown";
 import type {
 	MarkdownRuleDefinition,
 	MarkdownRuleVisitor,
+	MarkdownSourceCode,
 	Toml,
 	Json,
 	RangeMap,
 	Block,
-} from "@eslint/markdown/types";
-import { ESLint, Linter } from "eslint";
-import { Position } from "unist";
+} from "@eslint/markdown";
+import type { SourceLocation, SourceRange } from "@eslint/core";
+import type { ESLint, Linter } from "eslint";
+import type { Position } from "unist";
 import type {
 	// Nodes (abstract)
 	Node,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've exported all types from `src/types.ts` through the main entry point.

Previously, to access the global types defined in `src/types.ts`, they had to be imported from `@eslint/markdown/types`. After this change, they can be imported directly from `@eslint/markdown`.

#### What changes did you make? (Give an overview)

To enable importing types from the main entry point, I used a small trick.

The `types.ts` file is built into `types.js` and `types.d.ts`.

In the built `types.js`, it's possible to re-export the type declarations from the main entry point using `export * from "types.js"`.

However, that wasn't possible in the source. To bridge the gap, I added a dummy `src/types.js` file so types can be imported from `src/types.ts`.

#### Related Issues

Ref: https://github.com/eslint/json/issues/130, https://github.com/eslint/json/issues/130#issuecomment-3234058376, https://github.com/eslint/markdown/pull/453, https://github.com/eslint/markdown/pull/367#issuecomment-3010174602

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A