### PR TITLE
fix: handle consecutive backslashes in `no-reference-like-urls`

### DIFF
--- a/src/rules/no-reference-like-urls.js
+++ b/src/rules/no-reference-like-urls.js
@@ -29,7 +29,7 @@ import { findOffsets } from "../util.js";
 
 /** Pattern to match both inline links: `[text](url)` and images: `![alt](url)`, with optional title */
 const linkOrImagePattern =
-	/(?<!(?<!\\)\\)(?<imageBang>!)?\[(?<label>(?:\\.|[^()\\]|\([\s\S]*\))*?)\]\((?<destination>[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*(?:<[^>]*>|[^ \t()]+))(?:[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*(?<title>"[^"]*"|'[^']*'|\([^)]*\)))?[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*\)(?!\()/gu;
+	/(?<=(?<!\\)(?:\\{2})*)(?<imageBang>!)?\[(?<label>(?:\\.|[^()\\]|\([\s\S]*\))*?)\]\((?<destination>[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*(?:<[^>]*>|[^ \t()]+))(?:[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*(?<title>"[^"]*"|'[^']*'|\([^)]*\)))?[ \t]*(?:\r\n?|\n)?(?<![ \t])[ \t]*\)(?!\()/gu;
 
 /**
  * Checks if a given index is within any skip range.

--- a/src/rules/no-reference-like-urls.js
+++ b/src/rules/no-reference-like-urls.js
@@ -16,7 +16,7 @@ import { findOffsets } from "../util.js";
 
 /**
  * @import { SourceRange } from "@eslint/core"
- * @import { Heading, Node, Paragraph, TableCell } from "mdast";
+ * @import { Heading, Paragraph, TableCell } from "mdast";
  * @import { MarkdownRuleDefinition } from "../types.js";
  * @typedef {"referenceLikeUrl"} NoReferenceLikeUrlMessageIds
  * @typedef {[]} NoReferenceLikeUrlOptions

--- a/tests/rules/no-reference-like-urls.test.js
+++ b/tests/rules/no-reference-like-urls.test.js
@@ -155,6 +155,11 @@ ruleTester.run("no-reference-like-urls", rule, {
 			`,
 			language: "markdown/gfm",
 		},
+		// Backslash escaping
+		`${"\\".repeat(1)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+		`${"\\".repeat(3)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+		`${"\\".repeat(5)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+		`${"\\".repeat(7)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
 	],
 	invalid: [
 		{
@@ -1165,6 +1170,147 @@ ruleTester.run("no-reference-like-urls", rule, {
 					column: 13,
 					endLine: 4,
 					endColumn: 32,
+				},
+			],
+		},
+		// Backslash escaping
+		{
+			code: `${"\\".repeat(1)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(1)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(3)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(3)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(5)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(5)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(7)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(7)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(2)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(2)}[Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(4)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(4)}[Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(6)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(6)}[Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "link", prefix: "" },
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(2)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(2)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "image", prefix: "!" },
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(4)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(4)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "image", prefix: "!" },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
+			code: `${"\\".repeat(6)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
+			output: `${"\\".repeat(6)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
+			errors: [
+				{
+					messageId: "referenceLikeUrl",
+					data: { type: "image", prefix: "!" },
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

I've tried using consecutive backslashes in the `no-reference-like-urls` rule, but it reported false positives as shown below:

### What did you expect to happen?

#### First Problem

The code below doesn't report, which is the correct behavior.

```md
\[Mercury](mercury)

[mercury]: https://example.com/mercury
```

However, the code below does report, which are false positives:

```md
\\\[Mercury](mercury) <!-- False Positive -->

\\\\\[Mercury](mercury) <!-- False Positive -->

\\\\\\\[Mercury](mercury) <!-- False Positive -->

[mercury]: https://example.com/mercury
```

#### Second Problem

The code below is reported as a `link` type, which is the correct behavior.

```md
\![Mercury](mercury)

[mercury]: https://example.com/mercury
```

However, The code below is reported as an `image` type, which are incorrect behaviors.

The code below should be reported as a `link` type, since the `!` is escaped with a backslash.

```md
\\\![Mercury](mercury) <!-- Incorrect -->

\\\\\![Mercury](mercury) <!-- Incorrect -->

\\\\\\\![Mercury](mercury) <!-- Incorrect -->

[mercury]: https://example.com/mercury
```

### Link to minimal reproducible Example

Adding the following test cases would help identify the issues:

(Test cases not mentioned here but added were included just to verify the behavior.)

- `valid`:

```js
		`${"\\".repeat(3)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
		`${"\\".repeat(5)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
		`${"\\".repeat(7)}[Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
```

- `invalid`

```js
		{
			code: `${"\\".repeat(3)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
			output: `${"\\".repeat(3)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
			errors: [
				{
					messageId: "referenceLikeUrl",
					data: { type: "link", prefix: "" },
					line: 1,
					column: 5,
					endLine: 1,
					endColumn: 23,
				},
			],
		},
		{
			code: `${"\\".repeat(5)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
			output: `${"\\".repeat(5)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
			errors: [
				{
					messageId: "referenceLikeUrl",
					data: { type: "link", prefix: "" },
					line: 1,
					column: 7,
					endLine: 1,
					endColumn: 25,
				},
			],
		},
		{
			code: `${"\\".repeat(7)}![Mercury](mercury)\n\n[mercury]: https://example.com/mercury`,
			output: `${"\\".repeat(7)}![Mercury][mercury]\n\n[mercury]: https://example.com/mercury`,
			errors: [
				{
					messageId: "referenceLikeUrl",
					data: { type: "link", prefix: "" },
					line: 1,
					column: 9,
					endLine: 1,
					endColumn: 27,
				},
			],
		},
```		

## What changes did you make? (Give an overview)

This PR is a follow-up to #490.

In this PR, I've addressed false positives in `no-reference-like-urls` rule that were caused by consecutive backslash handling.

Previously, we used the following regex pattern to avoid matching backslash escapes:

- `(?<!(?<!\\)\\)` 

However, this pattern is incorrect because they don't properly handle consecutive backslash escapes metioned above.

So, I've updated them to use the following regex correctly:

- `(?<=(?<!\\)(?:\\{2})*)`

```js
(?<=(?<!\\)(?:\\{2})*)a
```

```txt
a           // even
\a          // odd
\\a         // even
\\\a        // odd
\\\\a       // even
\\\\\a      // odd
\\\\\\a     // even
```

<img width="273" height="284" alt="image" src="https://github.com/user-attachments/assets/64b757a7-6bcc-472f-abf9-bb82d364843c" />

<img width="1440" height="341" alt="image" src="https://github.com/user-attachments/assets/38cc6b3e-2e83-40db-8230-1a99720731af" />

## Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Ref: https://github.com/eslint/markdown/pull/490

## Is there anything you'd like reviewers to focus on?

In JavaScript, `\\\\\\\\` (8 backslashes) is interpreted as `\\\\` (4 backslashes) in Markdown, and is ultimately recognized as `\\` (2 backslashes). In this case, an even number of backslashes is not treated as an escape character and is recognized as a normal backslash.
