### PR TITLE
fix: `exactOptionalPropertyTypes` causes type errors when using plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,14 +19,13 @@ import rules from "./build/rules.js";
 
 /**
  * @import { Linter } from "eslint";
- * @typedef {Linter.RulesRecord} RulesRecord
  */
 
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
 
-/** @type {RulesRecord} */
+/** @type {Linter.RulesRecord} */
 const processorRulesConfig = {
 	// The Markdown parser automatically trims trailing
 	// newlines from code blocks.
@@ -98,7 +97,7 @@ const plugin = {
 				rules: recommendedRules,
 			},
 		],
-		processor: [
+		processor: /** @type {Linter.Config[]} */ ([
 			{
 				name: "markdown/recommended/plugin",
 				plugins: (processorPlugins = {}),
@@ -126,7 +125,7 @@ const plugin = {
 					...processorRulesConfig,
 				},
 			},
-		],
+		]),
 	},
 };
 

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -4,7 +4,8 @@
     "emitDeclarationOnly": false,
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true
+    "strict": true,
+    "exactOptionalPropertyTypes": true
   },
   "files": [],
   "include": [".", "../../dist"]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I’ve resolved the issue mentioned in #402.

I’ve confirmed that everything is working correctly by adding `exactOptionalPropertyTypes` to the tests and testing locally with a modified `index.d.ts` file.

### Why does this bug occur?

The bug was caused by the type signature of `configs.processor`. The `configs.processor` type was showing an unintended type signature, which led to the issue.

<img width="426" height="606" alt="image" src="https://github.com/user-attachments/assets/7a366a6a-d887-4983-8f07-c4feda1107f9" />

For example, after removing `config.processor` from `index.d.ts` entirely, the type error no longer occurs.

---

Looking into it further, the issue was caused by the commented "key-value" pair below. If we comment out these "key-value" pairs, the error no longer occurs.

<img width="472" height="485" alt="스크린샷 2025-09-15 011939" src="https://github.com/user-attachments/assets/51458547-ed29-433f-b41a-eaf612aced28" />

The commented-out "key-value" pairs above correspond to the JavaScript code below:

<img width="605" height="591" alt="image" src="https://github.com/user-attachments/assets/13aff880-6f7c-470e-afff-f82207c32ad7" />

There were no `files?: undefined;`, `processor?: undefined;`, or similar "key-value" pairs in the original JavaScript code, but they suddenly appeared when running `tsc`. These properties ended up causing the bug.

---

To address the issue, I cast the type of `configs.processor` as `Linter.Config[]`.

With this type casting, the `configs.processor` type now appears as shown in the following screenshot.

<img width="183" height="16" alt="image" src="https://github.com/user-attachments/assets/3db1785b-08d6-474a-b7c0-664984faf0ab" />

## What changes did you make? (Give an overview)

In this PR, I’ve resolved the issue mentioned in #402.

## Related Issues

Fixes: #402

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
