### PR TITLE
test: add package exports test

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "npm run build:rules && tsc && npm run build:update-rules-docs",
     "build:readme": "node tools/update-readme.js",
     "prepare": "npm run build",
-    "test": "mocha \"tests/**/*.test.js\" --timeout 30000",
+    "test": "mocha tests/**/*.test.js --timeout 30000",
     "test:coverage": "c8 npm test",
     "test:jsr": "npx jsr@latest publish --dry-run",
     "test:types": "tsc -p tests/types/tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "npm run build:rules && tsc && npm run build:update-rules-docs",
     "build:readme": "node tools/update-readme.js",
     "prepare": "npm run build",
-    "test": "mocha tests/**/*.test.js --timeout 30000",
+    "test": "mocha \"tests/**/*.test.js\" --timeout 30000",
     "test:coverage": "c8 npm test",
     "test:jsr": "npx jsr@latest publish --dry-run",
     "test:types": "tsc -p tests/types/tsconfig.json"

--- a/tests/package/exports.test.js
+++ b/tests/package/exports.test.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Tests for the package index's exports.
+ * @author Steve Dodier-Lazaro
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import * as exports from "../../src/index.js";
+import assert from "node:assert";
+
+import path from "node:path";
+import fs from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const rulesDir = path.resolve(dirname, "../../src/rules");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("Package exports", () => {
+	it("has the ESLint plugin as a default export", () => {
+		assert.deepStrictEqual(Object.keys(exports.default), [
+			"meta",
+			"processors",
+			"languages",
+			"rules",
+			"configs",
+		]);
+	});
+
+	it("has all available rules exported in the ESLint plugin", async () => {
+		const allRules = (await fs.readdir(rulesDir))
+			.filter(name => name.endsWith(".js"))
+			.map(name => name.slice(0, -".js".length))
+			.sort();
+		const exportedRules = exports.default.rules;
+
+		assert.deepStrictEqual(
+			Object.keys(exportedRules).sort(),
+			allRules,
+			"Expected all rules to be exported in the ESLint plugin (`plugin.rules` in `src/index.js`)",
+		);
+
+		for (const [ruleName, rule] of Object.entries(exportedRules)) {
+			assert.strictEqual(
+				rule,
+				(
+					await import(
+						pathToFileURL(path.resolve(rulesDir, `${ruleName}.js`))
+					)
+				).default,
+				`Expected ${ruleName}.js to be exported under key "${ruleName}" in the ESLint plugin (\`plugin.rules\` in \`src/index.js\`)`,
+			);
+		}
+	});
+
+	it("has a MarkdownSourceCode export", () => {
+		assert.ok(exports.MarkdownSourceCode);
+	});
+});

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -8,5 +8,5 @@
     "exactOptionalPropertyTypes": true
   },
   "files": [],
-  "include": [".", "../../dist"]
+  "include": ["**/*.test.ts", "../../dist"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To port the package exports test present in the other plugins into this repo for consistency and coverage.

#### What changes did you make? (Give an overview)

- Added a new test suite for src/index.js exports.
- Update the `includes` pattern in `tests/types/tsconfig.json` to only include file with a `.test` suffix.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
