### PR TITLE
refactor: use `getLocFromIndex` in `no-multiple-h1`

### DIFF
--- a/src/rules/no-multiple-h1.js
+++ b/src/rules/no-multiple-h1.js
@@ -74,9 +74,7 @@ export default {
 		let h1Count = 0;
 
 		return {
-			":matches(yaml, toml, json)"(
-				/** @type {Yaml | Toml | Json} */ node,
-			) {
+			"yaml, toml, json"(/** @type {Yaml | Toml | Json} */ node) {
 				if (frontmatterHasTitle(node.value, titlePattern)) {
 					h1Count++;
 				}

--- a/src/rules/no-multiple-h1.js
+++ b/src/rules/no-multiple-h1.js
@@ -98,12 +98,12 @@ export default {
 				let match;
 
 				while ((match = h1TagPattern.exec(text)) !== null) {
-					const [startOffset, endOffset] = match.indices[0].map(
-						index => index + node.position.start.offset,
-					); // Adjust `h1TagPattern` match indices to the full source code.
-
 					h1Count++;
 					if (h1Count > 1) {
+						const [startOffset, endOffset] = match.indices[0].map(
+							index => index + node.position.start.offset,
+						); // Adjust `h1TagPattern` match indices to the full source code.
+
 						context.report({
 							loc: {
 								start: sourceCode.getLocFromIndex(startOffset),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR originated from #536. While working on that, I found the scope had become too large, so I split this refactoring into a separate PR.

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

Notable changes:

- Replace the `findOffsets` util with the native `getLocFromIndex`.
- Use ESQuery selectors to reduce duplicated logic.

## What changes did you make? (Give an overview)

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

## Related Issues

Ref: #376, #536

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A