### PR TITLE
test: simplify Bun detection in tests

### DIFF
--- a/tests/rules/no-duplicate-definitions.test.js
+++ b/tests/rules/no-duplicate-definitions.test.js
@@ -153,10 +153,8 @@ ruleTester.run("no-duplicate-definitions", rule, {
 				},
 			],
 		},
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release?.name === "node" &&
-		!process.versions?.bun
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					{
 						code: `

--- a/tests/rules/no-empty-definitions.test.js
+++ b/tests/rules/no-empty-definitions.test.js
@@ -138,10 +138,8 @@ ruleTester.run("no-empty-definitions", rule, {
 			code: "[^note]:",
 			options: [{ allowFootnoteDefinitions: ["   note   "] }],
 		},
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release?.name === "node" &&
-		!process.versions?.bun
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					{
 						code: "[Grüsse]: #",

--- a/tests/rules/no-missing-link-fragments.test.js
+++ b/tests/rules/no-missing-link-fragments.test.js
@@ -277,11 +277,8 @@ ruleTester.run("no-missing-link-fragments", rule, {
 		`,
 
 		// Headings with emojis and accented characters
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release &&
-		process.release.name === "node" &&
-		(!process.versions || !process.versions.bun)
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					dedent`
 					# Heading with 🚀 emoji
@@ -749,11 +746,8 @@ ruleTester.run("no-missing-link-fragments", rule, {
 			],
 		},
 		// Headings with accented characters
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release &&
-		process.release.name === "node" &&
-		(!process.versions || !process.versions.bun)
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					{
 						code: dedent`

--- a/tests/rules/no-reference-like-urls.test.js
+++ b/tests/rules/no-reference-like-urls.test.js
@@ -1314,10 +1314,8 @@ ruleTester.run("no-reference-like-urls", rule, {
 				},
 			],
 		},
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release?.name === "node" &&
-		!process.versions?.bun
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					{
 						code: dedent`

--- a/tests/rules/no-unused-definitions.test.js
+++ b/tests/rules/no-unused-definitions.test.js
@@ -199,10 +199,8 @@ Mercury[^mercury]
 				},
 			],
 		},
-		// This test case is skipped for non-Node environments like Bun
-		...(typeof process !== "undefined" &&
-		process.release?.name === "node" &&
-		!process.versions?.bun
+		// This test case is skipped when running on Bun
+		...(!process.versions.bun
 			? [
 					{
 						code: "[Grüsse]: https://example.com/",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Simplify Bun detection in tests by replacing the verbose checks with the direct `process.versions.bun` detection

#### What changes did you make? (Give an overview)

Replaced all instances of `typeof process !== "undefined" && process.release?.name === "node" && !process.versions?.bun` with `!process.versions.bun` where tests should skip running on Bun.

#### Related Issues

Fixes #540

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
