### PR TITLE
fix: wrong location reporting in `no-invalid-label-refs`

### DIFF
--- a/docs/rules/no-invalid-label-refs.md
+++ b/docs/rules/no-invalid-label-refs.md
@@ -30,7 +30,6 @@ Examples of **incorrect** code for this rule:
 [eslint][ ]
 
 [eslint][
-
 ]
 ```
 

--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -102,7 +102,7 @@ function findInvalidLabelReferences(node, sourceCode) {
 		const startColumn = nodeStartColumn + startColumnOffset;
 		const endLine = nodeStartLine + endLineOffset;
 		const endColumn =
-			(endLine === startLine ? nodeStartColumn : 0) + endColumnOffset;
+			(endLine === startLine ? nodeStartColumn : 1) + endColumnOffset;
 
 		invalid.push({
 			label: label.trim(),

--- a/tests/rules/no-invalid-label-refs.test.js
+++ b/tests/rules/no-invalid-label-refs.test.js
@@ -31,6 +31,7 @@ ruleTester.run("no-invalid-label-refs", rule, {
 		"[foo][]\n\n[foo]: http://bar.com/image.jpg",
 		"![foo][]\n\n[foo]: http://bar.com/image.jpg",
 		"[  foo ][]\n\n[foo]: http://bar.com/image.jpg",
+		"[eslint][\n\n]",
 	],
 	invalid: [
 		{
@@ -68,7 +69,20 @@ ruleTester.run("no-invalid-label-refs", rule, {
 					line: 3,
 					column: 2,
 					endLine: 4,
-					endColumn: 1,
+					endColumn: 2,
+				},
+			],
+		},
+		{
+			code: "[\nfoo\n][\n ]\n\n[foo]: http://bar.com/image.jpg",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "foo" },
+					line: 3,
+					column: 2,
+					endLine: 4,
+					endColumn: 3,
 				},
 			],
 		},
@@ -163,6 +177,32 @@ ruleTester.run("no-invalid-label-refs", rule, {
 					column: 20,
 					endLine: 1,
 					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: "[eslint][ ]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "eslint" },
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: "[eslint][\n]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "eslint" },
+					line: 1,
+					column: 9,
+					endLine: 2,
+					endColumn: 2,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

The error location reported by `no-invalid-label-refs` is correct for single-line text, but in multi-line text, it's one index(offset) behind where I expect.

<img width="369" height="203" alt="image" src="https://github.com/user-attachments/assets/0e1f96aa-fd24-490d-aef5-f22fd98b7a8b" />

### What did you expect to happen?

I expected the error location to begin at `[` and end at `]`, but in multi-line text the end column is one index behind.

### Link to minimal reproducible Example

Adding the following test case to the `invalid` section would help identify the problem.

```js
		{
			code: "[\nfoo\n][\n]\n\n[foo]: http://bar.com/image.jpg",
			errors: [
				{
					messageId: "invalidLabelRef",
					data: { label: "foo" },
					line: 3,
					column: 2,
					endLine: 4,
					endColumn: 2,
				},
			],
		},
```

Originally, the `endColumn` was `1`, but it needs to be `2` so it includes `]` as it does for single-line text.

## What changes did you make? (Give an overview)

In this PR, I've fixed wrong location reporting in `no-invalid-label-refs`.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
