### PR TITLE
refactor: use `getLocFromIndex` in `no-invalid-label-refs`

### DIFF
--- a/src/rules/no-invalid-label-refs.js
+++ b/src/rules/no-invalid-label-refs.js
@@ -7,7 +7,7 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { findOffsets, illegalShorthandTailPattern } from "../util.js";
+import { illegalShorthandTailPattern } from "../util.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -17,23 +17,23 @@ import { findOffsets, illegalShorthandTailPattern } from "../util.js";
  * @import { Position } from "unist";
  * @import { Text } from "mdast";
  * @import { MarkdownRuleDefinition } from "../types.js";
+ * @import { MarkdownSourceCode } from "../index.js";
  * @typedef {"invalidLabelRef"} NoInvalidLabelRefsMessageIds
  * @typedef {[]} NoInvalidLabelRefsOptions
  * @typedef {MarkdownRuleDefinition<{ RuleOptions: NoInvalidLabelRefsOptions, MessageIds: NoInvalidLabelRefsMessageIds }>} NoInvalidLabelRefsRuleDefinition
- * @typedef {Parameters<MarkdownRuleDefinition['create']>[0]['sourceCode']} SourceCode
  */
 
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
 
-// matches i.e., [foo][bar]
+/** matches i.e., `[foo][bar]` */
 const labelPattern = /\]\[([^\]]+)\]/u;
 
 /**
  * Finds missing references in a node.
  * @param {Text} node The node to check.
- * @param {SourceCode} sourceCode The Markdown source code object.
+ * @param {MarkdownSourceCode} sourceCode The Markdown source code object.
  * @returns {Array<{label:string,position:Position}>} The missing references.
  */
 function findInvalidLabelReferences(node, sourceCode) {
@@ -41,9 +41,6 @@ function findInvalidLabelReferences(node, sourceCode) {
 	const docText = sourceCode.text;
 	const invalid = [];
 	let startIndex = 0;
-	const offset = node.position.start.offset;
-	const nodeStartLine = node.position.start.line;
-	const nodeStartColumn = node.position.start.column;
 
 	/*
 	 * This loop works by searching the string inside the node for the next
@@ -66,16 +63,16 @@ function findInvalidLabelReferences(node, sourceCode) {
 		}
 
 		/*
-		 * Calculate the match index relative to just the node and
-		 * to the entire document text.
+		 * Adjust `labelPattern` match index to the full source code.
 		 */
-		const nodeMatchIndex = startIndex + match.index;
-		const docMatchIndex = offset + nodeMatchIndex;
+		const startOffset =
+			startIndex + match.index + node.position.start.offset;
+		const endOffset = startOffset + match[0].length;
 
 		/*
 		 * Search the entire document text to find the preceding open bracket.
 		 */
-		const lastOpenBracketIndex = docText.lastIndexOf("[", docMatchIndex);
+		const lastOpenBracketIndex = docText.lastIndexOf("[", startOffset);
 
 		if (lastOpenBracketIndex === -1) {
 			startIndex += match.index + match[0].length;
@@ -87,34 +84,14 @@ function findInvalidLabelReferences(node, sourceCode) {
 		 * take that into account when calculating the line and column offsets.
 		 */
 		const label = docText
-			.slice(lastOpenBracketIndex, docMatchIndex + match[0].length)
+			.slice(lastOpenBracketIndex, endOffset)
 			.match(/!?\[([^\]]+)\]/u)[1];
-
-		// find location of [ in the document text
-		const { lineOffset: startLineOffset, columnOffset: startColumnOffset } =
-			findOffsets(nodeText, nodeMatchIndex + 1);
-
-		// find location of [ in the document text
-		const { lineOffset: endLineOffset, columnOffset: endColumnOffset } =
-			findOffsets(nodeText, nodeMatchIndex + match[0].length);
-
-		const startLine = nodeStartLine + startLineOffset;
-		const startColumn = nodeStartColumn + startColumnOffset;
-		const endLine = nodeStartLine + endLineOffset;
-		const endColumn =
-			(endLine === startLine ? nodeStartColumn : 1) + endColumnOffset;
 
 		invalid.push({
 			label: label.trim(),
 			position: {
-				start: {
-					line: startLine,
-					column: startColumn,
-				},
-				end: {
-					line: endLine,
-					column: endColumn,
-				},
+				start: sourceCode.getLocFromIndex(startOffset + 1),
+				end: sourceCode.getLocFromIndex(endOffset),
 			},
 		});
 

--- a/tests/rules/no-invalid-label-refs.test.js
+++ b/tests/rules/no-invalid-label-refs.test.js
@@ -206,5 +206,18 @@ ruleTester.run("no-invalid-label-refs", rule, {
 				},
 			],
 		},
+		{
+			code: "[*eslint*][ ]",
+			errors: [
+				{
+					messageId: "invalidLabelRef",
+					data: { label: "*eslint*" },
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 14,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR originated from #536. While working on that, I found the scope had become too large, so I split this refactoring into a separate PR.

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

Notable changes:

- Replace the `findOffsets` util with the native `getLocFromIndex`.
- Use ESQuery selectors to reduce duplicated logic.

## What changes did you make? (Give an overview)

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

## Related Issues

Ref: #376, #536

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A