### PR TITLE
refactor: use `getlocfromindex` in `no-missing-label-refs`

### DIFF
--- a/src/rules/no-missing-label-refs.js
+++ b/src/rules/no-missing-label-refs.js
@@ -17,7 +17,7 @@ import { illegalShorthandTailPattern } from "../util.js";
  * @import { Position } from "unist";
  * @import { Text } from "mdast";
  * @import { MarkdownRuleDefinition } from "../types.js";
- * @import { MarkdownSourceCode } from "../index.js"
+ * @import { MarkdownSourceCode } from "../language/markdown-source-code.js";
  * @typedef {"notFound"} NoMissingLabelRefsMessageIds
  * @typedef {[{ allowLabels?: string[] }]} NoMissingLabelRefsOptions
  * @typedef {MarkdownRuleDefinition<{ RuleOptions: NoMissingLabelRefsOptions, MessageIds: NoMissingLabelRefsMessageIds }>} NoMissingLabelRefsRuleDefinition


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR originated from #536. While working on that, I found the scope had become too large, so I split this refactoring into a separate PR.

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

Notable changes:

- Replace the `findOffsets` util with the native `getLocFromIndex`.

## What changes did you make? (Give an overview)

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

## Related Issues

Ref: #376, #536

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A