### PR TITLE
fix: correct the return type of `applyInlineConfig`

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -20,8 +20,9 @@ import { findOffsets } from "../util.js";
 //-----------------------------------------------------------------------------
 
 /**
+ * @import { Position } from "unist";
  * @import { Root, Node, Html } from "mdast";
- * @import { TraversalStep, SourceLocation, FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
+ * @import { TraversalStep, FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
  * @import { MarkdownLanguageOptions } from "../types.js";
  */
 
@@ -46,7 +47,7 @@ class InlineConfigComment {
 
 	/**
 	 * The position of the comment in the source code.
-	 * @type {SourceLocation}
+	 * @type {Position}
 	 */
 	position;
 
@@ -54,7 +55,7 @@ class InlineConfigComment {
 	 * Creates a new instance.
 	 * @param {Object} options The options for the instance.
 	 * @param {string} options.value The comment text.
-	 * @param {SourceLocation} options.position The position of the comment in the source code.
+	 * @param {Position} options.position The position of the comment in the source code.
 	 */
 	constructor({ value, position }) {
 		this.value = value.trim();
@@ -127,7 +128,7 @@ function extractInlineConfigCommentsFromHTML(node) {
 
 /**
  * Markdown Source Code Object
- * @extends {TextSourceCodeBase<{LangOptions: MarkdownLanguageOptions, RootNode: Root, SyntaxElementWithLoc: Node, ConfigNode: { value: string; position: SourceLocation }}>}
+ * @extends {TextSourceCodeBase<{LangOptions: MarkdownLanguageOptions, RootNode: Root, SyntaxElementWithLoc: Node, ConfigNode: { value: string; position: Position }}>}
  */
 export class MarkdownSourceCode extends TextSourceCodeBase {
 	/**
@@ -261,13 +262,13 @@ export class MarkdownSourceCode extends TextSourceCodeBase {
 	/**
 	 * Returns inline rule configurations along with any problems
 	 * encountered while parsing the configurations.
-	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:SourceLocation}>}} Information
+	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:Position}>}} Information
 	 *      that ESLint needs to further process the rule configurations.
 	 */
 	applyInlineConfig() {
 		/** @type {Array<FileProblem>} */
 		const problems = [];
-		/** @type {Array<{config:{rules:RulesConfig},loc:SourceLocation}>} */
+		/** @type {Array<{config:{rules:RulesConfig},loc:Position}>} */
 		const configs = [];
 
 		this.getInlineConfigNodes().forEach(comment => {

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -124,6 +124,18 @@ typeof processorPlugins satisfies {};
 	null as AssertAllNamesIn<RecommendedRuleName, RuleName>;
 }
 
+{
+	type ApplyInlineConfigLoc = ReturnType<
+		MarkdownSourceCode["applyInlineConfig"]
+	>["configs"][0]["loc"];
+
+	// Check that `applyInlineConfig`'s return type includes correct `loc` structure.
+	const loc: ApplyInlineConfigLoc = {
+		start: { line: 1, column: 1, offset: 0 },
+		end: { line: 1, column: 1, offset: 0 },
+	};
+}
+
 (): MarkdownRuleDefinition => ({
 	create({ sourceCode }): MarkdownRuleVisitor {
 		sourceCode satisfies MarkdownSourceCode;
@@ -145,6 +157,10 @@ typeof processorPlugins satisfies {};
 			sourceCode.getParent(node) satisfies Node | undefined;
 			sourceCode.getAncestors(node) satisfies Node[];
 			sourceCode.getText(node) satisfies string;
+			sourceCode.applyInlineConfig().configs[0].loc.start
+				.offset satisfies Position["start"]["offset"];
+			sourceCode.applyInlineConfig().configs[0].loc.end
+				.offset satisfies Position["end"]["offset"];
 		}
 
 		return {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

I expected the return type of `applyInlineConfig().configs` — specifically `loc.start` and `loc.end` — to include an `offset` property, but they don't.

### What did you expect to happen?

I expect the types of `loc.start` and `loc.end` to include an `offset` property.

### Link to minimal reproducible Example

```js
import { MarkdownSourceCode } from "./src/index.js";

const markdownSourceCode = new MarkdownSourceCode({
	text: '<!-- eslint markdown/no-html: "error" -->',
	ast: {
		type: "root",
		children: [
			{
				type: "html",
				value: '<!-- eslint markdown/no-html: "error" -->',
				position: {
					start: {
						line: 1,
						column: 1,
						offset: 0,
					},
					end: {
						line: 1,
						column: 42,
						offset: 41,
					},
				},
			},
		],
		position: {
			start: {
				line: 1,
				column: 1,
				offset: 0,
			},
			end: {
				line: 1,
				column: 42,
				offset: 41,
			},
		},
	},
});

console.log(markdownSourceCode.applyInlineConfig().configs[0].loc);
```

If you run the code above, you'll see that `markdownSourceCode.applyInlineConfig().configs[0].loc.start` and `markdownSourceCode.applyInlineConfig().configs[0].loc.end` include an `offset` property. However, the return type doesn't reflect that `offset` property.

```bash
# Output
{
  start: { line: 1, column: 1, offset: 0 },
  end: { line: 1, column: 42, offset: 41 }
}
```

## What changes did you make? (Give an overview)

Looking at the origin of the `loc` property returned by `applyInlineConfig`, you'll find that it directly uses the `position` property of the `Html` node.

https://github.com/eslint/markdown/blob/88b9391f76e8fdf3cc64eaf9e4b51b2270ea6b57/src/language/markdown-source-code.js#L83-L85

https://github.com/eslint/markdown/blob/88b9391f76e8fdf3cc64eaf9e4b51b2270ea6b57/src/language/markdown-source-code.js#L98

https://github.com/eslint/markdown/blob/88b9391f76e8fdf3cc64eaf9e4b51b2270ea6b57/src/language/markdown-source-code.js#L87-L89

https://github.com/eslint/markdown/blob/88b9391f76e8fdf3cc64eaf9e4b51b2270ea6b57/src/language/markdown-source-code.js#L107

https://github.com/eslint/markdown/blob/88b9391f76e8fdf3cc64eaf9e4b51b2270ea6b57/src/language/markdown-source-code.js#L112-L115

The `position` property uses the `Position` type from `unist` as shown below, so technically it doesn’t match the `SourceLocation` type.

- `Position`

```js
interface Position {
    start: {
        line: number;
        column: number;
        offset?: number | undefined;
    }
    end: {
        line: number;
        column: number;
        offset?: number | undefined;
    }
}
```

- `SourceLocation`

```js
interface SourceLocation {
    start: {
        line: number;
        column: number;
    }
    end: {
        line: number;
        column: number;
    }
}
```

To provide a more accurate return type, I've replaced the `SourceLocation` type with the `Position` type from `unist`.

## Related Issues

Ref: https://github.com/eslint/css/pull/281, https://github.com/eslint/json/pull/162

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A