### PR TITLE
refactor: use `getLocFromIndex` in `no-html`

### DIFF
--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -82,16 +82,16 @@ export default {
 				while ((match = htmlTagPattern.exec(node.value)) !== null) {
 					const fullMatch = match[0];
 					const { tagName } = match.groups;
-					const startOffset =
-						node.position.start.offset + match.index;
-
 					const firstNewlineIndex =
 						fullMatch.search(lineEndingPattern);
 
+					const startOffset =
+						match.index + node.position.start.offset;
 					const endOffset =
-						firstNewlineIndex === -1
-							? startOffset + fullMatch.length
-							: startOffset + firstNewlineIndex;
+						startOffset +
+						(firstNewlineIndex === -1
+							? fullMatch.length
+							: firstNewlineIndex);
 
 					const tagToCheck = allowedIgnoreCase
 						? tagName.toLowerCase()

--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -70,9 +70,17 @@ export default {
 	create(context) {
 		const { sourceCode } = context;
 		const [{ allowed, allowedIgnoreCase }] = context.options;
-		const allowedElements = new Set(
-			allowedIgnoreCase ? allowed.map(tag => tag.toLowerCase()) : allowed,
-		);
+
+		/**
+		 * Normalize a tag name based on the `allowedIgnoreCase` option.
+		 * @param {string} tagName The tag name to normalize.
+		 * @returns {string} The normalized tag name.
+		 */
+		function normalizeTagName(tagName) {
+			return allowedIgnoreCase ? tagName.toLowerCase() : tagName;
+		}
+
+		const allowedElements = new Set(allowed.map(normalizeTagName));
 
 		return {
 			html(node) {
@@ -85,7 +93,7 @@ export default {
 					const firstNewlineIndex =
 						fullMatch.search(lineEndingPattern);
 
-					const startOffset =
+					const startOffset = // Adjust `htmlTagPattern` match index to the full source code.
 						match.index + node.position.start.offset;
 					const endOffset =
 						startOffset +
@@ -93,11 +101,7 @@ export default {
 							? fullMatch.length
 							: firstNewlineIndex);
 
-					const tagToCheck = allowedIgnoreCase
-						? tagName.toLowerCase()
-						: tagName;
-
-					if (!allowedElements.has(tagToCheck)) {
+					if (!allowedElements.has(normalizeTagName(tagName))) {
 						context.report({
 							loc: {
 								start: sourceCode.getLocFromIndex(startOffset),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR originated from #536. While working on that, I found the scope had become too large, so I split this refactoring into a separate PR.

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

Notable changes:

- Replace the `findOffsets` util with the native `getLocFromIndex`.
- Use a named capture group in `htmlTagPattern` for better readability.
- Consolidate the tag-name normalization logic (`allowedIgnoreCase ? tagName.toLowerCase() : tagName`) into a single helper function, `normalizeTagName`.
- Remove the unnecessary `allowedElements.size === 0` check from the `if` clause when reporting.

## What changes did you make? (Give an overview)

In this PR, I've used the native `getLocFromIndex` method added in #376 instead of the custom `findOffsets` util.

## Related Issues

Ref: #376, #536

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A