### PR TITLE
fix: report locations in `no-multiple-h1` and `require-alt-text`

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -72,7 +72,7 @@ export function frontmatterHasTitle(value, pattern) {
 
 /**
  * Replaces all HTML comments with whitespace.
- * This preserves indexes and locations of characters
+ * This preserves offsets and locations of characters
  * outside HTML comments by keeping line breaks and replacing
  * other code units with a space character.
  * @param {string} value The string to remove HTML comments from.

--- a/src/util.js
+++ b/src/util.js
@@ -71,12 +71,18 @@ export function frontmatterHasTitle(value, pattern) {
 }
 
 /**
- * Remove all HTML comments from a string.
+ * Replaces all HTML comments with whitespace.
+ * This preserves indexes and locations of characters
+ * outside HTML comments by keeping line breaks and replacing
+ * other code units with a space character.
  * @param {string} value The string to remove HTML comments from.
  * @returns {string} The string with HTML comments removed.
  */
 export function stripHtmlComments(value) {
 	return value.replace(htmlCommentPattern, match =>
-		match.replace(/[^\n]/gu, " "),
+		/* eslint-disable-next-line require-unicode-regexp
+		   -- we want to replace each code unit with a space
+		*/
+		match.replace(/[^\r\n]/g, " "),
 	);
 }

--- a/tests/rules/no-multiple-h1.test.js
+++ b/tests/rules/no-multiple-h1.test.js
@@ -1203,7 +1203,7 @@ ruleTester.run("no-multiple-h1", rule, {
 			],
 		},
 		{
-			// NOTE dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
+			// NOTE: dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
 			code: "<h1>Heading 1</h1>\n<!-- comment with surrogate pairs: 👍🚀 --> <h1>Another H1</h1>",
 			errors: [
 				{

--- a/tests/rules/no-multiple-h1.test.js
+++ b/tests/rules/no-multiple-h1.test.js
@@ -1203,10 +1203,8 @@ ruleTester.run("no-multiple-h1", rule, {
 			],
 		},
 		{
-			code: dedent`
-				<h1>Heading 1</h1>
-				<!-- comment with surrogate pairs: 👍🚀 --> <h1>Another H1</h1>
-			`,
+			// NOTE dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
+			code: "<h1>Heading 1</h1>\n<!-- comment with surrogate pairs: 👍🚀 --> <h1>Another H1</h1>",
 			errors: [
 				{
 					messageId: "multipleH1",

--- a/tests/rules/no-multiple-h1.test.js
+++ b/tests/rules/no-multiple-h1.test.js
@@ -1202,5 +1202,20 @@ ruleTester.run("no-multiple-h1", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`
+				<h1>Heading 1</h1>
+				<!-- comment with surrogate pairs: 👍🚀 --> <h1>Another H1</h1>
+			`,
+			errors: [
+				{
+					messageId: "multipleH1",
+					line: 2,
+					column: 45,
+					endLine: 2,
+					endColumn: 64,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -310,7 +310,7 @@ ruleTester.run("require-alt-text", rule, {
 			],
 		},
 		{
-			// NOTE dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
+			// NOTE: dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
 			code: '<!-- comment with surrogate pairs: 👍🚀 --> <img src="image.png" />',
 			errors: [
 				{

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -309,5 +309,19 @@ ruleTester.run("require-alt-text", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`
+				<!-- comment with surrogate pairs: 👍🚀 --> <img src="image.png" />
+			`,
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 45,
+					endLine: 1,
+					endColumn: 68,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -310,9 +310,8 @@ ruleTester.run("require-alt-text", rule, {
 			],
 		},
 		{
-			code: dedent`
-				<!-- comment with surrogate pairs: 👍🚀 --> <img src="image.png" />
-			`,
+			// NOTE dedent`` converts 👍🚀 to \u{1f44d}\u{1f680} in Bun, causing unexpected report locations
+			code: '<!-- comment with surrogate pairs: 👍🚀 --> <img src="image.png" />',
 			errors: [
 				{
 					messageId: "altTextRequired",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes report location in the `no-multiple-h1` and `require-alt-text` rules in cases where a preceding HTML comment has characters consisting of Unicode surrogate pairs.

<img width="717" height="275" alt="image" src="https://github.com/user-attachments/assets/43f9a6fa-e93d-4b36-97d8-1f2c9db0fac7" />


#### What changes did you make? (Give an overview)

Updated `utils.stripHtmlComments` to replace each code unit (instead of code point) with a space. This preserves offsets and locations of characters outside HTML comments.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
