### PR TITLE
fix!: remove `/types` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     ".": {
       "types": "./dist/esm/index.d.ts",
       "default": "./dist/esm/index.js"
-    },
-    "./types": {
-      "types": "./dist/esm/types.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've removed the `/types` export.

This change was mentioned in https://github.com/eslint/rewrite/issues/403#issuecomment-3234058376 and was postponed until a breaking change occurred. Now that #561 is pending and introduces such a breaking change, I've opened this PR.

This change is also related to https://github.com/eslint/markdown/pull/520, which exports types from the main entry point.

## What changes did you make? (Give an overview)

In this PR, I've removed the `/types` export. 

This change is a breaking change.

## Related Issues

<!-- include tags like "fixes eslint/json#123" or "refs eslint/json#123" -->

Refs: https://github.com/eslint/rewrite/issues/403#issuecomment-3234058376, https://github.com/eslint/markdown/pull/520

## Is there anything you'd like reviewers to focus on?

N/A