### PR TITLE
fix: correct parent typing for rule visitors

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -23,7 +23,7 @@ import { lineEndingPattern } from "../util.js";
  * @import { Position } from "unist";
  * @import { Root, Node, Html } from "mdast";
  * @import { TraversalStep, FileProblem, DirectiveType, RulesConfig } from "@eslint/core";
- * @import { MarkdownLanguageOptions } from "../types.js";
+ * @import { MarkdownLanguageOptions, MarkdownSyntaxElement } from "../types.js";
  */
 
 //-----------------------------------------------------------------------------
@@ -113,7 +113,7 @@ function extractInlineConfigCommentsFromHTML(node, sourceCode) {
 
 /**
  * Markdown Source Code Object
- * @extends {TextSourceCodeBase<{LangOptions: MarkdownLanguageOptions, RootNode: Root, SyntaxElementWithLoc: Node, ConfigNode: { value: string; position: Position }}>}
+ * @extends {TextSourceCodeBase<{LangOptions: MarkdownLanguageOptions, RootNode: Root, SyntaxElementWithLoc: MarkdownSyntaxElement, ConfigNode: { value: string; position: Position }}>}
  */
 export class MarkdownSourceCode extends TextSourceCodeBase {
 	/**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates `MarkdownRuleVisitor` so that the parent parameter has a precise type for non-root nodes.

#### What changes did you make? (Give an overview)

- Added `ParentOf<T>` utility to infer correct parent types.
- For non-root nodes, the `parent` parameter is now precisely typed; for root, only the `node` is passed.
- Introduced `MarkdownSyntaxElement`, consistent with the CSS and JSON plugins.
- Updated `MarkdownSourceCode` to reference `MarkdownSyntaxElement`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
