### PR TITLE
fix: wrong location reporting in `require-alt-text`

### DIFF
--- a/src/rules/require-alt-text.js
+++ b/src/rules/require-alt-text.js
@@ -72,7 +72,7 @@ export default {
 			},
 
 			html(node) {
-				const text = stripHtmlComments(node.value);
+				const text = stripHtmlComments(sourceCode.getText(node));
 
 				/** @type {RegExpExecArray} */
 				let match;

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -258,6 +258,42 @@ ruleTester.run("require-alt-text", rule, {
 			],
 		},
 		{
+			code: '<img\n src="image.png" />',
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 1,
+					endLine: 2,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: '<img\n  src="image.png" />',
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 1,
+					endLine: 2,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: '<img\n   src="image.png" />',
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 1,
+					endLine: 2,
+					endColumn: 22,
+				},
+			],
+		},
+		{
 			code: dedent`
 				<!-- <img src="image.png" /> -->
 				<img src="image.png" />


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

I expected a multi-line `<img>` tag to report the correct location, but it doesn't for the example below:

<img width="352" height="287" alt="image" src="https://github.com/user-attachments/assets/f7e80456-3fd0-452f-b1d8-9b08f41eee55" />

### What did you expect to happen?

I expect a multi-line `<img>` tag to report the correct location.

### Link to minimal reproducible Example

The following Markdown code may help identify the problem:

```md
<!-- eslint markdown/require-alt-text: "error" -->

<!-- Correct -->

<img 
src="https://example.com/image.png">

<!-- Incorrect -->

<img 
 src="https://example.com/image.png">

<img 
  src="https://example.com/image.png"> 

<img 
   src="https://example.com/image.png">
```

## What changes did you make? (Give an overview)

In this PR, I've fixed wrong location reporting in `require-alt-text` rule.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A