### PR TITLE
chore: correct regex pattern for `eslint-plugin/report-message-format`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,7 +98,7 @@ export default defineConfig([
 			"eslint-plugin/require-meta-schema": "off", // `schema` defaults to []
 			"eslint-plugin/prefer-placeholders": "error",
 			"eslint-plugin/prefer-replace-text": "error",
-			"eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
+			"eslint-plugin/report-message-format": ["error", "^[^a-z].*\\.$"],
 			"eslint-plugin/require-meta-docs-description": [
 				"error",
 				{ pattern: "^(Enforce|Require|Disallow) .+[^. ]$" },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've corrected the regex pattern for `eslint-plugin/report-message-format` in `eslint.config.js`.

It seems the original intent of this regex was to enforce a capital first character, but the current regex matches strings like the following:

<img width="301" height="162" alt="image" src="https://github.com/user-attachments/assets/13a28dde-ae9b-4eb8-8356-120b2b6e4e18" />

I've updated the regex to correctly identify messages that start with a lowercase letter.

#### What changes did you make? (Give an overview)

In this PR, I've corrected the regex pattern for `eslint-plugin/report-message-format` in `eslint.config.js`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
