### PR TITLE
feat: Support .mdc files as Markdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,11 +68,11 @@ const plugin = {
 			plugins: ["markdown"],
 			overrides: [
 				{
-					files: ["*.md"],
+					files: ["*.{md,mdc}"],
 					processor: "markdown/markdown",
 				},
 				{
-					files: ["**/*.md/**"],
+					files: ["**/*.{md,mdc}/**"],
 					parserOptions: {
 						ecmaFeatures: {
 							// Adding a "use strict" directive at the top of
@@ -91,7 +91,7 @@ const plugin = {
 		recommended: [
 			{
 				name: "markdown/recommended",
-				files: ["**/*.md"],
+				files: ["**/*.{md,mdc}"],
 				language: "markdown/commonmark",
 				plugins: (recommendedPlugins = {}),
 				rules: recommendedRules,
@@ -104,12 +104,12 @@ const plugin = {
 			},
 			{
 				name: "markdown/recommended/processor",
-				files: ["**/*.md"],
+				files: ["**/*.{md,mdc}"],
 				processor: "markdown/markdown",
 			},
 			{
 				name: "markdown/recommended/code-blocks",
-				files: ["**/*.md/**"],
+				files: ["**/*.{md,mdc}/**"],
 				languageOptions: {
 					parserOptions: {
 						ecmaFeatures: {


### PR DESCRIPTION
# feat: Support .mdc files as Markdown

## Summary

Adds support for `.mdc` files (Markdown Component files used by Cursor and Nuxt) by including them in the recommended configs. This ensures `.mdc` files are automatically recognized as markdown and processed correctly, preventing ESLint from falling back to the JavaScript parser.

## Problem

When ESLint configs match `.mdc` files (or other markdown-like extensions) but don't set the `language` or `processor` property, ESLint falls back to the JavaScript parser. The JavaScript parser then attempts to parse the entire markdown file (including YAML frontmatter) as JavaScript code, resulting in confusing errors like:

```
Parsing error: Assigning to rvalue
```

`.mdc` files are essentially Markdown files used by:

- **Cursor AI**: Rule files with YAML frontmatter and XML-like tags
- **Nuxt.js**: Markdown Component files with embedded Vue components

These files should be treated as markdown, but the plugin's recommended configs only match `.md` files.

## Solution

Extend the recommended configs to also match `.mdc` files:

- `markdown.configs.recommended`: Include `.mdc` files
- `markdown.configs.processor`: Include `.mdc` files
- `markdown.configs["recommended-legacy"]`: Include `.mdc` files

This ensures that when users use the recommended configs, `.mdc` files are automatically handled as markdown without requiring manual configuration.

## Changes

- **src/index.js**: Updated file patterns in all recommended configs:
  - `files: ["**/*.md"]` → `files: ["**/*.{md,mdc}"]`
  - `files: ["**/*.md/**"]` → `files: ["**/*.{md,mdc}/**"]`
  - `files: ["*.md"]` → `files: ["*.{md,mdc}"]`

## Testing

- ✅ All existing tests pass
- ✅ `.mdc` files are now matched by recommended configs
- ✅ Code blocks in `.mdc` files are properly extracted and linted
- ✅ Backward compatibility maintained (`.md` files continue to work)

## Backward Compatibility

This change is fully backward compatible:

- `.md` files continue to work exactly as before
- No breaking changes to the API
- Only adds support for an additional file extension

## Related

Closes #587

## Additional Context

- `.mdc` files are standard Markdown with tool-specific extensions
- Cursor uses `.mdc` for rule files with YAML frontmatter
- Nuxt uses `.mdc` for Markdown Component syntax
- Both use standard Markdown syntax and should be linted as markdown

## Reproduction

See [StackBlitz reproduction case](https://stackblitz.com/edit/stackblitz-starters-jt7ykgxv) that demonstrates the error when `.mdc` files are matched without language/processor configuration.
