### PR TITLE
fix: false positive triggered by HTML inside comments in `no-html`

### DIFF
--- a/src/rules/no-html.js
+++ b/src/rules/no-html.js
@@ -7,7 +7,7 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { lineEndingPattern } from "../util.js";
+import { lineEndingPattern, stripHtmlComments } from "../util.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -89,10 +89,12 @@ export default {
 
 		return {
 			html(node) {
+				const text = stripHtmlComments(sourceCode.getText(node));
+
 				/** @type {RegExpExecArray} */
 				let match;
 
-				while ((match = htmlTagPattern.exec(node.value)) !== null) {
+				while ((match = htmlTagPattern.exec(text)) !== null) {
 					const fullMatch = match[0];
 					const { tagName } = match.groups;
 					const firstNewlineIndex =

--- a/tests/rules/no-html.test.js
+++ b/tests/rules/no-html.test.js
@@ -28,6 +28,9 @@ ruleTester.run("no-html", rule, {
 		"Hello world!",
 		" 1 < 5",
 		"<!-- comment -->",
+		"<!-- <h1> -->",
+		'<!-- <div id="foo"> -->',
+		"<!-- abcdefg <abcdefg> -->",
 		dedent`\`\`\`html
         <b>Hello world!</b>
         \`\`\``,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

I expected HTML tag syntax in comments not to trigger the `no-html` rule. 

However, currently HTML tag syntax within comments triggers this rule, as shown below:

<img width="363" height="124" alt="image" src="https://github.com/user-attachments/assets/ebaa7853-a653-4b80-b575-26aa8f25a68d" />

### What did you expect to happen?

I expected HTML tag syntax in comments not to trigger the `no-html` rule. 

### Link to minimal reproducible Example

The following Markdown code may help identify the problem:

```md
<!-- eslint markdown/no-html: "error" -->
 
<!-- <h1> -->
<!-- <div id="foo"> -->
<!-- abcdefg <abcdefg> -->
```

## What changes did you make? (Give an overview)

In this PR, I've fixed false positive triggered by HTML inside comments in `no-html`.

I've simply reused the `stripHtmlComments` util to resolve this issue. This is a common pattern in Markdown rules, as shown below:

https://github.com/eslint/markdown/blob/55e3f4be32137c865b48da538c7511219984e75d/src/rules/require-alt-text.js#L75-L80

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
