### PR TITLE
ci: run `arethetypeswrong` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
               run: npm install eslint@${{  matrix.eslint  }}
             - name: Test
               run: npm run test
+
     test_types:
         name: Test Types
         runs-on: ubuntu-latest
@@ -84,10 +85,23 @@ jobs:
                   node-version: "lts/*"
             - name: Install dependencies
               run: npm install
-            - name: Build
-              run: npm run build
             - name: Check Types
               run: npm run test:types
+
+    are-the-types-wrong:
+        name: Are the types wrong?
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: "lts/*"
+            - name: Install Packages
+              run: npm install
+            - name: Check validity of type definitions
+              run: npm run lint:types
+
     jsr_test:
         name: Verify JSR Publish
         runs-on: ubuntu-latest
@@ -99,6 +113,4 @@ jobs:
             - name: Install Packages
               run: npm install
             - name: Run --dry-run
-              run: |
-                  npm run build
-                  npm run test:jsr
+              run: npm run test:jsr

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "lint": "eslint && eslint -c eslint.config-content.js",
     "lint:fix": "eslint --fix && eslint --fix -c eslint.config-content.js",
+    "lint:types": "attw --pack --profile esm-only",
     "lint:unused": "knip",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
@@ -74,6 +75,7 @@
     "test:types": "tsc -p tests/types/tsconfig.json"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@eslint/js": "^9.39.1",
     "@eslint/json": "^0.14.0",
     "@types/mdast": "^4.0.4",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR is a follow-up to https://github.com/eslint/rewrite/pull/338.

I've added the `arethetypeswrong` check to CI to validate package types, using `eslint` and `eslint-config-eslint` from the main repo as examples (https://github.com/eslint/eslint/blob/v10.0.0-alpha.1/.github/workflows/types-integration.yml#L181-L210).

I also removed a redundant `npm run build` after `npm install` from the workflows, since it already runs during `prepare`.

https://github.com/eslint/markdown/blob/a2ccff86ba536894fddbcfc89cb8d56567a22ac4/package.json#L70

#### What changes did you make? (Give an overview)

In this PR, I've added the `arethetypeswrong` check to CI to validate package types.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
