### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# #270 chore: Enable Prettier
+7d918daaf7de149a1899f060e515293aaccbef35
+# #591 chore: update `prettier` to fix CI
+55e3f4be32137c865b48da538c7511219984e75d


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR was motivated by https://github.com/eslint/tsc-meetings/pull/651.

In this PR, I've added `.git-blame-ignore-revs`.

Adding a [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) file prevents the squash-merged Prettier commit from appearing in GitHub's blame view.

There were some formatting-only commits in the `markdown` repository due to newly introduced or released Prettier versions; adding this file would help prevent noisy entries in git blame views in the future.

I followed the same format used in the `eslint` repository: https://github.com/eslint/eslint/blob/main/.git-blame-ignore-revs

## What changes did you make? (Give an overview)

In this PR, I've added `.git-blame-ignore-revs`.

## Related Issues

Ref: https://github.com/eslint/tsc-meetings/pull/651

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A