### PR TITLE
chore: fix CI failure caused by `knip`

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,8 @@
   "workspaces": {
     ".": {
       "entry": ["tests/**/*.test.{js,ts}", "tests/fixtures/*.js"],
-      "project": ["**"]
+      "project": ["**"],
+      "ignore": ["src/types.ts"]
     },
     "examples/*": {
       "entry": ["**/*.*s"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've fixed a CI failure caused by `knip`.

The CI was failing for the following reason:

<img width="1490" height="210" alt="image" src="https://github.com/user-attachments/assets/d5575f11-c110-4688-8337-99020ce1dc52" />

Ref: https://github.com/eslint/markdown/actions/runs/21048356568/job/60528486284

All CI checks passed for https://github.com/eslint/markdown/pull/564, but it seems the branch wasn't up to date, so a conflict occurred with https://github.com/eslint/markdown/pull/466.

## What changes did you make? (Give an overview)

I've used `"ignore": ["src/types.ts"]` since all types from `src/types.ts` are re-exported via `dist/esm/index.js` (the main entry point).

Because re-exporting all types in `src/types.ts` from the main entry point via `src/index.js` is somewhat of a hack around the type-generation logic, I'm not sure there's another clearer way to resolve this `knip` issue.

https://github.com/eslint/markdown/blob/28eecf6f178ecb31e47cc67dbe32c6286aae4dec/src/types.js#L1-L10

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A