### PR TITLE
chore: run build before type tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test": "mocha \"tests/**/*.test.js\" --timeout 30000",
     "test:coverage": "c8 npm test",
     "test:jsr": "npx -y jsr@latest publish --dry-run",
-    "test:types": "tsc -p tests/types/tsconfig.json"
+    "test:types": "npm run build && tsc -p tests/types/tsconfig.json"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Currently, running `npm run test:types` requires manually running `npm run build` first to ensure type declarations are up-to-date. This change automates that step so type tests always run against the latest build.

#### What changes did you make? (Give an overview)

Updated the `test:types` script to run `npm run build` before type checking.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
