### PR TITLE
docs: add blank lines after ESLint directive comments

### DIFF
--- a/docs/rules/no-duplicate-definitions.md
+++ b/docs/rules/no-duplicate-definitions.md
@@ -25,6 +25,7 @@ Examples of **incorrect** code:
 
 ```markdown
 <!-- eslint markdown/no-duplicate-definitions: "error" -->
+
 <!-- definition -->
 
 [mercury]: https://example.com/mercury/
@@ -46,6 +47,7 @@ Examples of **correct** code:
 
 ```markdown
 <!-- eslint markdown/no-duplicate-definitions: "error" -->
+
 <!-- definition -->
 
 [mercury]: https://example.com/mercury/
@@ -72,6 +74,7 @@ The following options are available on this rule:
 
     ```markdown
     <!-- eslint markdown/no-duplicate-definitions: ["error", { allowDefinitions: ["mercury"] }] -->
+
     [mercury]: https://example.com/mercury/
     [mercury]: https://example.com/venus/
     ```
@@ -82,6 +85,7 @@ The following options are available on this rule:
 
     ```markdown
     <!-- eslint markdown/no-duplicate-definitions: ["error", { allowFootnoteDefinitions: ["mercury"] }] -->
+
     [^mercury]: Hello, Mercury!
     [^mercury]: Hello, Venus!
     ```


### PR DESCRIPTION
Fixes #613

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes formatting inconsistency in rule documentation. 

#### What changes did you make? (Give an overview)

Added blank lines after ESLint directive comments in                              
docs/rules/no-duplicate-definitions.md at four locations to match the formatting  
convention used in all other rule documentation files.                           
                                                                                    
- Pattern 1 (lines 27, 48)

Before:
```markdown
<!-- eslint markdown/no-duplicate-definitions: "error" -->
<!-- definition -->
```

After:
```markdown
<!-- eslint markdown/no-duplicate-definitions: "error" -->

<!-- definition -->
```

- Pattern 2 (lines 74, 84)

Before:
```markdown
<!-- eslint markdown/no-duplicate-definitions: ["error", { allowDefinitions:      
["mercury"] }] -->                                                                
[mercury]: https://example.com/mercury/
```
                                                                               
After:                                                                            
```markdown
<!-- eslint markdown/no-duplicate-definitions: ["error", { allowDefinitions:      
  ["mercury"] }] -->                                                                
                                                             
[mercury]: https://example.com/mercury/
```


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Fixes #613 

#### Is there anything you'd like reviewers to focus on?
