### PR TITLE
fix: report messages for configuration comments correctly

### DIFF
--- a/docs/processors/markdown.md
+++ b/docs/processors/markdown.md
@@ -180,6 +180,8 @@ Comment bodies are passed through unmodified, so the plugin supports any [config
 
 This example enables the `alert` global variable, disables the `no-alert` rule, and configures the `quotes` rule to prefer single quotes:
 
+<!-- eslint-skip -->
+
 ````markdown
 <!-- global alert -->
 <!-- eslint-disable no-alert -->
@@ -191,6 +193,8 @@ alert('Hello, world!');
 ````
 
 Each code block in a file is linted separately, so configuration comments apply only to the code block that immediately follows.
+
+<!-- eslint-skip -->
 
 ````markdown
 Assuming `no-alert` is enabled in `eslint.config.js`, the first code block will have no error from `no-alert`:

--- a/eslint.config-content.js
+++ b/eslint.config-content.js
@@ -3,7 +3,7 @@ import markdown from "./src/index.js";
 
 export default defineConfig([
 	globalIgnores(
-		["**/*.js", "**/.cjs", "**/.mjs"],
+		["**/*.js", "**/.cjs", "**/.mjs", "**/tests/fixtures/**"],
 		"markdown/content/ignores",
 	),
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -16,11 +16,10 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 /**
  * @import { Node, Parent, Code, Html } from "mdast";
  * @import { Linter, Rule, AST } from "eslint";
- * @import { Block, RangeMap } from "./types.js";
+ * @import { Block, MappedCommentLocation, RangeMap } from "./types.js";
  * @typedef {Linter.LintMessage} Message
  * @typedef {Rule.Fix} Fix
  * @typedef {AST.Range} Range
- * @typedef {{ text: string, position: { start: { line: number, column: number }, end?: { line: number, column: number } } }} CommentInfo
  */
 
 //-----------------------------------------------------------------------------
@@ -40,8 +39,8 @@ const SUPPORTS_AUTOFIX = true;
  * @returns {string} A JS block comment string.
  */
 function wrapComment(text) {
-	const prefix = /^[\s*]/u.test(text) ? "" : " ";
-	const suffix = /[\s*]$/u.test(text) ? "" : " ";
+	const prefix = /^\s/u.test(text) ? "" : " ";
+	const suffix = /\s$/u.test(text) ? "" : " ";
 
 	return `/*${prefix}${text}${suffix}*/`;
 }
@@ -295,7 +294,7 @@ function preprocess(sourceText, filename) {
 	 * block immediately follows such a sequence, insert the comments at the
 	 * top of the code block. Any non-ESLint comment or other node type breaks
 	 * and empties the sequence.
-	 * @type {CommentInfo[]}
+	 * @type {MappedCommentLocation[]}
 	 */
 	let htmlComments = [];
 
@@ -314,7 +313,7 @@ function preprocess(sourceText, filename) {
 				/** @type {string[]} */
 				const comments = [];
 
-				/** @type {CommentInfo[]} */
+				/** @type {MappedCommentLocation[]} */
 				const commentInfos = [];
 
 				for (const commentInfo of htmlComments) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,9 +60,18 @@ export interface RangeMap {
 	md: number;
 }
 
+export interface CommentInfo {
+	text: string;
+	position: {
+		start: { line: number; column: number };
+		end?: { line: number; column: number };
+	};
+}
+
 export interface BlockBase {
 	baseIndentText: string;
 	comments: string[];
+	commentInfos: CommentInfo[];
 	rangeMap: RangeMap[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface RangeMap {
 	md: number;
 }
 
-export interface CommentInfo {
+export interface MappedCommentLocation {
 	text: string;
 	position: {
 		start: { line: number; column: number };
@@ -71,7 +71,7 @@ export interface CommentInfo {
 export interface BlockBase {
 	baseIndentText: string;
 	comments: string[];
-	commentInfos: CommentInfo[];
+	commentInfos: MappedCommentLocation[];
 	rangeMap: RangeMap[];
 }
 

--- a/tests/fixtures/eslint.config.js
+++ b/tests/fixtures/eslint.config.js
@@ -9,6 +9,9 @@ export default [
 		languageOptions: {
 			globals: globals.browser,
 		},
+		linterOptions: {
+			reportUnusedDisableDirectives: "off",
+		},
 		rules: {
 			"eol-last": "error",
 			"no-console": "error",

--- a/tests/fixtures/eslintrc.json
+++ b/tests/fixtures/eslintrc.json
@@ -3,6 +3,7 @@
   "env": {
     "browser": true
   },
+  "reportUnusedDisableDirectives": false,
   "plugins": ["markdown"],
   "overrides": [
     {

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -1175,6 +1175,145 @@ describe("LegacyESLint", () => {
 			});
 		});
 	});
+
+	// https://github.com/eslint/markdown/issues/115
+	describe("reportUnusedDisableDirectives", () => {
+		let eslint;
+
+		beforeEach(() => {
+			eslint = new LegacyESLint({
+				useEslintrc: false,
+				plugins: { markdown: plugin },
+				reportUnusedDisableDirectives: "error",
+				overrideConfig: {
+					plugins: ["markdown"],
+					overrides: [
+						{
+							files: ["**/*.md"],
+							processor: "markdown/markdown",
+						},
+						{
+							files: ["**/*.md/*.js"],
+							rules: {
+								"no-console": "error",
+							},
+						},
+					],
+				},
+			});
+		});
+
+		it("should report unused disable directives with correct line numbers", async () => {
+			const code = [
+				"# Test",
+				"",
+				"<!-- eslint-disable no-undef -->",
+				"",
+				"```js",
+				'console.log("hello");',
+				"```",
+			].join("\n");
+
+			const results = await eslint.lintText(code, {
+				filePath: "test.md",
+			});
+
+			// Should report both: unused disable directive + no-console
+			assert.strictEqual(results[0].messages.length, 2);
+
+			// First message should be the unused disable directive
+			assert.ok(
+				results[0].messages[0].message.includes("no-undef"),
+			);
+			// Line should point to the HTML comment in Markdown (line 3)
+			assert.strictEqual(results[0].messages[0].line, 3);
+
+			// Second message should be the no-console error
+			assert.strictEqual(
+				results[0].messages[1].message,
+				"Unexpected console statement.",
+			);
+			assert.strictEqual(results[0].messages[1].line, 6);
+		});
+
+		it("should report unused disable directives for multi-line HTML comments", async () => {
+			const code = [
+				"# Test",
+				"",
+				"<!--",
+				"  eslint-disable no-undef",
+				"-->",
+				"",
+				"```js",
+				"var x = 1;",
+				"```",
+			].join("\n");
+
+			const results = await eslint.lintText(code, {
+				filePath: "test.md",
+			});
+
+			assert.strictEqual(results[0].messages.length, 1);
+			assert.ok(
+				results[0].messages[0].message.includes("no-undef"),
+			);
+			// Line should point to the start of the multi-line HTML comment
+			assert.strictEqual(results[0].messages[0].line, 3);
+		});
+
+		it("should report unused disable directives for multiple HTML comments before a code block", async () => {
+			const code = [
+				"# Test",
+				"",
+				"<!-- eslint-disable no-undef -->",
+				"<!-- eslint-disable no-alert -->",
+				"",
+				"```js",
+				'console.log("hello");',
+				"```",
+			].join("\n");
+
+			const results = await eslint.lintText(code, {
+				filePath: "test.md",
+			});
+
+			// Should report: unused no-undef + unused no-alert + no-console
+			assert.strictEqual(results[0].messages.length, 3);
+
+			// First unused directive (no-undef) should point to line 3
+			assert.strictEqual(results[0].messages[0].line, 3);
+			assert.ok(results[0].messages[0].message.includes("no-undef"));
+
+			// Second unused directive (no-alert) should point to line 4
+			assert.strictEqual(results[0].messages[1].line, 4);
+			assert.ok(results[0].messages[1].message.includes("no-alert"));
+
+			// Third message should be the no-console error on line 7
+			assert.strictEqual(results[0].messages[2].line, 7);
+		});
+
+		it("should not include fix or suggestions for configuration comment messages", async () => {
+			const code = [
+				"# Test",
+				"",
+				"<!-- eslint-disable no-undef -->",
+				"",
+				"```js",
+				"var x = 1;",
+				"```",
+			].join("\n");
+
+			const results = await eslint.lintText(code, {
+				filePath: "test.md",
+			});
+
+			assert.strictEqual(results[0].messages.length, 1);
+			assert.strictEqual(results[0].messages[0].fix, undefined);
+			assert.strictEqual(results[0].messages[0].suggestions, undefined);
+			assert.strictEqual(results[0].messages[0].endLine, undefined);
+			assert.strictEqual(results[0].messages[0].endColumn, undefined);
+		});
+	});
 });
 
 describe("FlatESLint", () => {
@@ -2405,8 +2544,10 @@ describe("FlatESLint", () => {
 
 	// https://github.com/eslint/markdown/issues/115
 	describe("reportUnusedDisableDirectives", () => {
-		it("should report unused disable directives with correct line numbers", async () => {
-			const eslintWithUnusedDirectives = new ESLint({
+		let eslint;
+
+		beforeEach(() => {
+			eslint = new ESLint({
 				overrideConfigFile: true,
 				overrideConfig: [
 					{
@@ -2429,7 +2570,9 @@ describe("FlatESLint", () => {
 					},
 				],
 			});
+		});
 
+		it("should report unused disable directives with correct line numbers", async () => {
 			const code = [
 				"# Test",
 				"",
@@ -2440,7 +2583,7 @@ describe("FlatESLint", () => {
 				"```",
 			].join("\n");
 
-			const results = await eslintWithUnusedDirectives.lintText(code, {
+			const results = await eslint.lintText(code, {
 				filePath: "test.md",
 			});
 
@@ -2464,24 +2607,6 @@ describe("FlatESLint", () => {
 		});
 
 		it("should report unused disable directives for multi-line HTML comments", async () => {
-			const eslintWithUnusedDirectives = new ESLint({
-				overrideConfigFile: true,
-				overrideConfig: [
-					{
-						plugins: {
-							markdown: plugin,
-						},
-						linterOptions: {
-							reportUnusedDisableDirectives: "error",
-						},
-					},
-					{
-						files: ["*.md"],
-						processor: "markdown/markdown",
-					},
-				],
-			});
-
 			const code = [
 				"# Test",
 				"",
@@ -2494,7 +2619,7 @@ describe("FlatESLint", () => {
 				"```",
 			].join("\n");
 
-			const results = await eslintWithUnusedDirectives.lintText(code, {
+			const results = await eslint.lintText(code, {
 				filePath: "test.md",
 			});
 
@@ -2508,30 +2633,6 @@ describe("FlatESLint", () => {
 		});
 
 		it("should report unused disable directives for multiple HTML comments before a code block", async () => {
-			const eslintWithUnusedDirectives = new ESLint({
-				overrideConfigFile: true,
-				overrideConfig: [
-					{
-						plugins: {
-							markdown: plugin,
-						},
-						linterOptions: {
-							reportUnusedDisableDirectives: "error",
-						},
-					},
-					{
-						files: ["*.md"],
-						processor: "markdown/markdown",
-					},
-					{
-						files: ["**/*.js"],
-						rules: {
-							"no-console": "error",
-						},
-					},
-				],
-			});
-
 			const code = [
 				"# Test",
 				"",
@@ -2543,7 +2644,7 @@ describe("FlatESLint", () => {
 				"```",
 			].join("\n");
 
-			const results = await eslintWithUnusedDirectives.lintText(code, {
+			const results = await eslint.lintText(code, {
 				filePath: "test.md",
 			});
 
@@ -2563,24 +2664,6 @@ describe("FlatESLint", () => {
 		});
 
 		it("should not include fix or suggestions for configuration comment messages", async () => {
-			const eslintWithUnusedDirectives = new ESLint({
-				overrideConfigFile: true,
-				overrideConfig: [
-					{
-						plugins: {
-							markdown: plugin,
-						},
-						linterOptions: {
-							reportUnusedDisableDirectives: "error",
-						},
-					},
-					{
-						files: ["*.md"],
-						processor: "markdown/markdown",
-					},
-				],
-			});
-
 			const code = [
 				"# Test",
 				"",
@@ -2591,7 +2674,7 @@ describe("FlatESLint", () => {
 				"```",
 			].join("\n");
 
-			const results = await eslintWithUnusedDirectives.lintText(code, {
+			const results = await eslint.lintText(code, {
 				filePath: "test.md",
 			});
 

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -1222,9 +1222,7 @@ describe("LegacyESLint", () => {
 			assert.strictEqual(results[0].messages.length, 2);
 
 			// First message should be the unused disable directive
-			assert.ok(
-				results[0].messages[0].message.includes("no-undef"),
-			);
+			assert.ok(results[0].messages[0].message.includes("no-undef"));
 			// Line should point to the HTML comment in Markdown (line 3)
 			assert.strictEqual(results[0].messages[0].line, 3);
 
@@ -1254,9 +1252,7 @@ describe("LegacyESLint", () => {
 			});
 
 			assert.strictEqual(results[0].messages.length, 1);
-			assert.ok(
-				results[0].messages[0].message.includes("no-undef"),
-			);
+			assert.ok(results[0].messages[0].message.includes("no-undef"));
 			// Line should point to the start of the multi-line HTML comment
 			assert.strictEqual(results[0].messages[0].line, 3);
 		});

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -6,6 +6,7 @@ import type {
 	Toml,
 	Json,
 	RangeMap,
+	MappedCommentLocation,
 	Block,
 } from "@eslint/markdown";
 import type { Plugin, SourceLocation, SourceRange } from "@eslint/core";
@@ -57,6 +58,12 @@ const validBlock: Block = {
 	// `BlockBase` properties
 	baseIndentText: "  ",
 	comments: ["// A comment"],
+	commentInfos: [
+		{
+			text: "// A comment",
+			position: { start: { line: 1, column: 1 } },
+		},
+	],
 	rangeMap: [{ indent: 2, js: 0, md: 4 }],
 };
 
@@ -71,6 +78,7 @@ validBlock.data satisfies CodeData | undefined;
 // Verify `Block` has `BlockBase` properties
 validBlock.baseIndentText satisfies string;
 validBlock.comments satisfies string[];
+validBlock.commentInfos satisfies MappedCommentLocation[];
 validBlock.rangeMap satisfies RangeMap[];
 
 // Verify `RangeMap` structure


### PR DESCRIPTION
## Summary

Previously, ESLint messages that pointed to configuration comments (such as unused disable directive warnings) were being silently dropped because the `adjustMessage` function returned `null` for any message pointing to lines before the actual code content.

This change:
- Tracks the original HTML comment positions when collecting configuration comments from the Markdown
- Builds a mapping from linted code line numbers to original comment info
- Maps messages pointing to configuration comment lines back to their original HTML comment locations in the Markdown file

This fixes the issue where `--report-unused-disable-directives` would not work with the markdown processor, as those warnings were being filtered out.

### Before
```
$ eslint --report-unused-disable-directives README.md
# (no output even when there are unused disable directives)
```

### After
```
$ eslint --report-unused-disable-directives README.md
README.md
  3:1  warning  Unused eslint-disable directive (no problems were reported from 'no-undef')
```

## Test plan
- [x] Added new test suite `reportUnusedDisableDirectives` with tests for single-line and multi-line HTML comments
- [x] All existing 1590 tests pass
- [x] Lint passes

Fixes #115