### PR TITLE
refactor: remove unnecessary string coercion from `data`

### DIFF
--- a/src/rules/heading-increment.js
+++ b/src/rules/heading-increment.js
@@ -91,8 +91,8 @@ export default {
 						loc: node.position,
 						messageId: "skippedHeading",
 						data: {
-							fromLevel: lastHeadingDepth.toString(),
-							toLevel: node.depth.toString(),
+							fromLevel: lastHeadingDepth,
+							toLevel: node.depth,
 						},
 					});
 				}

--- a/src/rules/no-duplicate-definitions.js
+++ b/src/rules/no-duplicate-definitions.js
@@ -113,8 +113,7 @@ export default {
 						data: {
 							identifier: node.identifier,
 							label: node.label.trim(),
-							firstLine:
-								firstDefinitionNode.position.start.line.toString(),
+							firstLine: firstDefinitionNode.position.start.line,
 							firstLabel: firstDefinitionNode.label.trim(),
 						},
 					});
@@ -142,7 +141,7 @@ export default {
 							identifier: node.identifier,
 							label: node.label,
 							firstLine:
-								firstFootnoteDefinitionNode.position.start.line.toString(),
+								firstFootnoteDefinitionNode.position.start.line,
 							firstLabel: firstFootnoteDefinitionNode.label,
 						},
 					});

--- a/src/rules/table-column-count.js
+++ b/src/rules/table-column-count.js
@@ -81,8 +81,8 @@ export default {
 							},
 							messageId: "extraCells",
 							data: {
-								actualCells: String(actualCellsLength),
-								expectedCells: String(expectedCellsLength),
+								actualCells: actualCellsLength,
+								expectedCells: expectedCellsLength,
 							},
 						});
 					} else if (
@@ -101,8 +101,8 @@ export default {
 							},
 							messageId: "missingCells",
 							data: {
-								actualCells: String(actualCellsLength),
-								expectedCells: String(expectedCellsLength),
+								actualCells: actualCellsLength,
+								expectedCells: expectedCellsLength,
 							},
 						});
 					}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR removes unnecessary string coercion from the `data` property.

As of `@eslint/core@1.0.1`, the `data` property's type was widened to `string | number | boolean | bigint | null | undefined` in https://github.com/eslint/rewrite/pull/327, so string coercion is no longer necessary.

The coercion was previously used to avoid TypeScript errors, so it can be removed.

## What changes did you make? (Give an overview)

This PR removes unnecessary string coercion from the `data` property.

## Related Issues

Ref: https://github.com/eslint/rewrite/pull/327

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
