### PR TITLE
chore: ignore `eslint-v9` for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
 	$schema: "https://docs.renovatebot.com/renovate-schema.json",
 	extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
+	ignoreDeps: ["eslint-v9"],
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Stop Renovate from opening PRs that upgrade the `eslint-v9` npm alias to v10.

#### What changes did you make? (Give an overview)

Updated `.github/renovate.json5` to add `ignoreDeps: ["eslint-v9"]`

#### Related Issues

https://github.com/eslint/markdown/pull/630

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
