### PR TITLE
docs: use `defineConfig` in `markdown.md` example

### DIFF
--- a/docs/processors/markdown.md
+++ b/docs/processors/markdown.md
@@ -46,13 +46,14 @@ To enable the Markdown processor, use the `processor` configuration, which conta
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import markdown from "@eslint/markdown";
 
-export default [
-    ...markdown.configs.processor
+export default defineConfig([
+    markdown.configs.processor
 
     // your other configs here
-];
+]);
 ```
 
 ## Advanced Configuration
@@ -76,9 +77,10 @@ Here's an example:
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import markdown from "@eslint/markdown";
 
-export default [
+export default defineConfig([
     {
         // 1. Add the plugin
         plugins: {
@@ -101,7 +103,7 @@ export default [
     }
 
     // your other configs here
-];
+]);
 ```
 
 ## Frequently-Disabled Rules
@@ -119,9 +121,10 @@ Use glob patterns to disable more rules just for Markdown code blocks:
 
 ```js
 // / eslint.config.js
+import { defineConfig } from "eslint/config";
 import markdown from "@eslint/markdown";
 
-export default [
+export default defineConfig([
     {
         plugins: {
             markdown
@@ -142,7 +145,7 @@ export default [
     }
 
     // your other configs here
-];
+]);
 ```
 
 ## Additional Notes


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates `markdown.md` to use the `defineConfig` helper, which is now the recommended way to define configurations.

I noticed `markdown.md` was missing this while I was reviewing another PR, so I updated it accordingly.

#### What changes did you make? (Give an overview)

This PR updates `markdown.md` to use the `defineConfig` helper, which is now the recommended way to define configurations.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
