### PR TITLE
fix: allow `InlineConfigComment` node to be reported

### DIFF
--- a/src/language/markdown-source-code.js
+++ b/src/language/markdown-source-code.js
@@ -38,7 +38,7 @@ const htmlComment = /<!--(.*?)-->/gsu;
 /**
  * Represents an inline config comment in the source code.
  */
-class InlineConfigComment {
+export class InlineConfigComment {
 	/**
 	 * The comment text.
 	 * @type {string}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,10 @@ import type {
 	CustomRuleTypeDefinitions,
 	CustomRuleVisitorWithExit,
 } from "@eslint/plugin-kit";
-import type { MarkdownSourceCode } from "./index.js";
+import type {
+	InlineConfigComment,
+	MarkdownSourceCode,
+} from "./language/markdown-source-code.js";
 
 //------------------------------------------------------------------------------
 // Exports: Processor
@@ -135,6 +138,11 @@ export interface MarkdownLanguageOptions extends LanguageOptions {
  */
 export type MarkdownLanguageContext = LanguageContext<MarkdownLanguageOptions>;
 
+/**
+ * A Markdown syntax element, including nodes and comments.
+ */
+type MarkdownSyntaxElement = Node | InlineConfigComment;
+
 export interface MarkdownRuleVisitor
 	extends
 		RuleVisitor,
@@ -187,7 +195,7 @@ export type MarkdownRuleDefinition<
 		LangOptions: MarkdownLanguageOptions;
 		Code: MarkdownSourceCode;
 		Visitor: MarkdownRuleVisitor;
-		Node: Node;
+		Node: MarkdownSyntaxElement;
 	},
 	Options
 >;

--- a/tests/language/markdown-source-code.test.js
+++ b/tests/language/markdown-source-code.test.js
@@ -296,9 +296,9 @@ describe("MarkdownSourceCode", () => {
 
 	describe("getInlineConfigNodes()", () => {
 		it("should return `InlineConfigComment` instances", () => {
-			const nodes = sourceCode.getInlineConfigNodes();
+			const inlineConfigNodes = sourceCode.getInlineConfigNodes();
 
-			for (const node of nodes) {
+			for (const node of inlineConfigNodes) {
 				assert.ok(node instanceof InlineConfigComment);
 			}
 		});

--- a/tests/language/markdown-source-code.test.js
+++ b/tests/language/markdown-source-code.test.js
@@ -8,7 +8,10 @@
 //------------------------------------------------------------------------------
 
 import assert from "node:assert";
-import { MarkdownSourceCode } from "../../src/language/markdown-source-code.js";
+import {
+	InlineConfigComment,
+	MarkdownSourceCode,
+} from "../../src/language/markdown-source-code.js";
 import { fromMarkdown } from "mdast-util-from-markdown";
 
 //------------------------------------------------------------------------------
@@ -292,6 +295,14 @@ describe("MarkdownSourceCode", () => {
 	});
 
 	describe("getInlineConfigNodes()", () => {
+		it("should return `InlineConfigComment` instances", () => {
+			const nodes = sourceCode.getInlineConfigNodes();
+
+			for (const node of nodes) {
+				assert.ok(node instanceof InlineConfigComment);
+			}
+		});
+
 		it("should return the inline config nodes", () => {
 			const nodes = sourceCode.getInlineConfigNodes();
 			assert.strictEqual(nodes.length, 10);

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -372,3 +372,21 @@ const invalidLanguageOptions2: MarkdownLanguageOptions = {
 		},
 	},
 });
+
+// `context.report` should accept nodes returned by `getInlineConfigNodes`
+(): MarkdownRuleDefinition => ({
+	create(context) {
+		const inlineConfigNodes = context.sourceCode.getInlineConfigNodes();
+
+		return {
+			"root:exit"() {
+				for (const node of inlineConfigNodes) {
+					context.report({
+						node,
+						messageId: "message",
+					});
+				}
+			},
+		};
+	},
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

When writing rules, I expected nodes from `sourceCode#getInlineConfigNodes` to be reportable by `context.report`, but it shows a type error like in the screenshot below:

<img width="826" height="356" alt="image" src="https://github.com/user-attachments/assets/a324182d-69f2-4d30-986a-fb059e28f00a" />

This is a valid violation report, and ESLint shows the correct positional information when using this method, but only a TypeScript type error is reported.

### What did you expect to happen?

No type error occurs.

### Link to minimal reproducible Example

1. Create the following file at `src/rules/test.js` in `@eslint/markdown` repository.

```js
/**
 * @fileoverview Test
 */

//-----------------------------------------------------------------------------
// Type Definitions
//-----------------------------------------------------------------------------

/**
 * @import { MarkdownRuleDefinition } from "../types.js";
 * @typedef {'message'} MessageIds
 * @typedef {[]} Options
 * @typedef {MarkdownRuleDefinition<{ RuleOptions: Options, MessageIds: MessageIds }>} RuleDefinition
 */

//-----------------------------------------------------------------------------
// Rule Definition
//-----------------------------------------------------------------------------

/** @type {RuleDefinition} */
export default {
	meta: {
		type: "problem",

		docs: {
			recommended: true,
			description: "Enforce test",
			url: "https://github.com/eslint/markdown/blob/main/docs/rules/test.md",
		},

		messages: {
			message: "Test Test Test.",
		},
	},

	create(context) {
		const inlineConfigNodes = context.sourceCode.getInlineConfigNodes();

		return {
			"root:exit"() {
				for (const node of inlineConfigNodes) {
					context.report({
						node,
						messageId: "message",
					});
				}
			},
		};
	},
};
```

2. Now, TypeScript reports a type incompatibility for `node`, as shown below:

```txt
Property 'type' is missing in type 'InlineConfigComment' but required in type 'Node'.
```

## What changes did you make? (Give an overview)

This PR fixes a similar issue that also affected the JSON language in https://github.com/eslint/json/pull/210.

The root cause is that the `Node` type from `mdast` has a `type` property, but the `InlineConfigComment` class doesn't declare a `type` property, and this discrepancy causes the type error.

For example, in rough form:

```ts
// Node
interface Node {
    type: string;
    position?: Position | undefined;
    data?: Data | undefined;
}

// InlineConfigComment
interface InlineConfigComment {
    value: string;
    position: Position;
}
```

I've updated the `MarkdownRuleDefinition` type to accept `InlineConfigComment` instances as valid violation reports.

## Related Issues

Ref: https://github.com/eslint/json/pull/210

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

Just a note that the return types of `CSSSourceCode#getInlineConfigNodes` and `JSONSourceCode#getInlineConfigNodes` are already compatible with their respective `CSSRuleDefinition` and `JSONRuleDefinition`.