### PR TITLE
docs: Add missing "Prior Art" link to no-empty-definitions

### DIFF
--- a/docs/rules/no-empty-definitions.md
+++ b/docs/rules/no-empty-definitions.md
@@ -88,4 +88,5 @@ If you aren't concerned with empty definitions, you can safely disable this rule
 
 ## Prior Art
 
+* [MD042 - no-empty-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md)
 * [remark-lint-no-empty-url](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-empty-url)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Add a missing attribution.

#### What changes did you make? (Give an overview)

Added the missing attribution.

#### Related Issues

N/A

#### Is there anything you'd like reviewers to focus on?

For context, see other rules that reference same-named/same-behavior `markdownlint` rules as "Prior Art".