### PR TITLE
chore: update @arethetypeswrong/cli to 0.18.3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
 	$schema: "https://docs.renovatebot.com/renovate-schema.json",
 	extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
-	ignoreDeps: ["eslint-v9", "fflate"],
+	ignoreDeps: ["eslint-v9"],
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.3",
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^1.2.0",
     "@types/mdast": "^4.0.4",
@@ -109,11 +109,6 @@
     "micromark-extension-gfm": "^3.0.0",
     "micromark-extension-math": "^3.1.0",
     "micromark-util-normalize-identifier": "^2.0.1"
-  },
-  "overrides": {
-    "@arethetypeswrong/core": {
-      "fflate": "0.8.2"
-    }
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates `@arethetypeswrong/cli` to version `0.18.3`. This update resolves a previous dependency issue, allowing us to clean up the temporary `fflate` workaround.

#### What changes did you make? (Give an overview)

- Updated `@arethetypeswrong/cli` from `^0.18.2` to `^0.18.3`.
- Removed the `fflate` version override and removed `fflate` from Renovate's `ignoreDeps` list.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
