### PR TITLE
chore: add prettier update commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,5 @@
 7d918daaf7de149a1899f060e515293aaccbef35
 # #591 chore: update `prettier` to fix CI
 55e3f4be32137c865b48da538c7511219984e75d
+# #675 chore: update prettier to v3.9.0
+09e69fe3aef47d965ceb1b35157831c5399e5e14


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR simply adds the `prettier` update commit from #675 to `.git-blame-ignore-revs` so formatting-only diffs won’t show up in the `git blame` view.

#### What changes did you make? (Give an overview)

Added a commit SHA to `.git-blame-ignore-revs`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
