### PR TITLE
docs: add eslint to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ Lint Markdown with ESLint, as well JS, JSX, TypeScript, and more inside Markdown
 
 Install the plugin alongside ESLint v9.15.0 or greater. Type compatibility is guaranteed with ESLint v9.39.0 or greater.
 
-For Node.js and compatible runtimes:
+You can install ESLint using npm or other package managers:
+
+```sh
+npm install eslint -D
+# or
+yarn add eslint -D
+# or
+pnpm install eslint -D
+# or
+bun add eslint -D
+```
+
+Then, for Node.js and compatible runtimes:
 
 ```sh
 npm install @eslint/markdown -D


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

The `@eslint/markdown` package does not declare `eslint` as a peer dependency. 
As a result, users may assume that installing `@eslint/markdown` will also install ESLint, but ESLint must actually be installed separately in order to use the plugin. 

The existing installation instructions only include `@eslint/markdown`, which may cause new users to miss a required dependency. To prevent this, the documentation now instructs users to install `eslint` before installing `@eslint/markdown`.


#### What changes did you make? (Give an overview)

Updated the installation instructions for @eslint/markdown to clarify that eslint must be installed separately before installing the plugin, consistent with the change made in eslint/json#258.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
