### PR TITLE
ci: declare least-privilege contents: read on add-to-triage

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,6 +12,9 @@ on:
             - opened
             - reopened
 
+permissions:
+    contents: read
+
 jobs:
     add-to-triage:
         uses: eslint/workflows/.github/workflows/add-to-triage.yml@main


### PR DESCRIPTION
<!--
    Thank you for contributing!
    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

The `add-to-triage.yml` workflow has no workflow-level `permissions` declaration, so `GITHUB_TOKEN` is granted the default permissions. This restricts them explicitly, following the principle of least privilege.

#### What changes did you make? (Give an overview)

Added a workflow-level `permissions` block to `.github/workflows/add-to-triage.yml`.

```yaml
permissions:
    contents: read
```

This workflow uses `secrets.PROJECT_BOT_TOKEN` for the project board operations, so `GITHUB_TOKEN` does not need any additional permissions.

#### Related Issues

Refs #686
Refs eslint/.github#20

#### Is there anything you'd like reviewers to focus on?