### PR TITLE
chore: add yorkie to allowScripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
     "test:types:7.x": "npx -p @typescript/native-preview@latest -y -- tsgo -p tests/types/tsconfig.json",
     "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
+  "allowScripts": {
+    "yorkie": true
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.3",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Add the `allowScripts` field to `package.json` for the npm install scripts policy, following the same approach as [eslint/eslint#21092](https://github.com/eslint/eslint/pull/21092)

#### What changes did you make? (Give an overview)
npm 11.16.0 introduced phase 1 of the `allowScripts` policy, where install scripts still run but npm warns about any package with an install script not covered by `allowScripts`. Starting with npm 12, unapproved install scripts will no longer run by default.

On a fresh install, this repository shows the following warning.

```
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   yorkie@2.0.0 (install: node bin/install.js)
```
`yorkie` is the only dependency here with an install script, and it is required, since it installs the git hooks that run `lint-staged` on commit. I left the entry unpinned (`"yorkie": true`) instead of pinning the version, since this repository does not commit a lockfile, so a pinned version would make the warning reappear once a new `yorkie` version is resolved.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
Verified with npm 11.16.0, after running a fresh install. The warning appears without `allowScripts` and disappears with `"yorkie": true`. The pre-commit hook is created correctly in both cases, and `npm test` passes.
