### PR TITLE
docs: correct allowPattern value in no-missing-link-fragments example

### DIFF
--- a/docs/rules/no-missing-link-fragments.md
+++ b/docs/rules/no-missing-link-fragments.md
@@ -94,7 +94,7 @@ This rule supports the following options:
 * `allowPattern: string` -
     A regular expression string. If a link fragment matches this pattern, it will be ignored by the rule. This is useful for fragments that are dynamically generated or handled by other tools. (default: `""`)
 
-    Examples of **correct** code when configured as `"no-missing-link-fragments": ["error", { allowPattern: "" }]`:
+    Examples of **correct** code when configured as `"no-missing-link-fragments": ["error", { allowPattern: "^figure-" }]`:
 
     ```markdown
     <!-- eslint markdown/no-missing-link-fragments: ["error", { allowPattern: "^figure-" }] -->


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

- Documentation update

<img width="726" height="269" alt="image" src="https://github.com/user-attachments/assets/961ec7a3-8522-4ed7-8d58-b9c8d2eae975" />

Hi! This is a small fix for the `allowPattern` example in the `no-missing-link-fragments` docs.

The heading introduces the example as configured with `{ allowPattern: "" }`, but the code block right below it actually uses `{ allowPattern: "^figure-" }`, so the two don't line up.

`"^figure-"` is the value that makes the example correct: it matches the `#figure-19` fragment so the rule ignores it. With an empty `allowPattern`, that fragment isn't ignored and the rule reports `Link fragment '#figure-19' does not reference a heading or anchor in this document`, so the snippet wouldn't be a "correct" example. Updating the heading to `"^figure-"` matches the code block.

#### What changes did you make? (Give an overview)

Changed the `allowPattern` value in the heading from `""` to `"^figure-"` so it matches the example below it. One line in `docs/rules/no-missing-link-fragments.md`.

#### Related Issues

None

#### Is there anything you'd like reviewers to focus on?

Nothing in particular. It's a docs-only one-line change.