### PR TITLE
docs: clarify that content and code fences can't be linted together

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ export default defineConfig([
 | ------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [`markdown`](./docs/processors/markdown.md) | Extract fenced code blocks from the Markdown code so they can be linted separately. |
 
+**Important:** You cannot lint a file's Markdown content and its fenced code blocks in the same run. When the `markdown` processor is applied to a file, only the extracted code blocks are linted — any Markdown rules (such as `markdown/heading-increment`) configured for that file are silently ignored. This is an ESLint limitation, not something this plugin can work around. See [Workarounds](./docs/processors/markdown.md#workarounds) for ways to lint both.
+
 ## Migration from `eslint-plugin-markdown`
 
 See [Migration](./docs/migration.md#from-eslint-plugin-markdown).

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ export default defineConfig([
 | ------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [`markdown`](./docs/processors/markdown.md) | Extract fenced code blocks from the Markdown code so they can be linted separately. |
 
-**Important:** You cannot lint a file's Markdown content and its fenced code blocks in a single ESLint run. When the `markdown` processor is applied to a file, only the extracted code blocks are linted; any Markdown-specific rules configured for the original file, such as `markdown/heading-increment`, are silently ignored. This is a current limitation of ESLint processors. See [Workarounds](./docs/processors/markdown.md#workarounds) for ways to lint both.
+**Important:** You cannot lint a file's Markdown content and its fenced code blocks in a single ESLint run. When the `markdown` processor is applied, only the extracted code blocks are linted. This is a current limitation of ESLint processors. See [Linting Markdown Content and Code Blocks](./docs/processors/markdown.md#linting-markdown-content-and-code-blocks) for a way to lint both.
 
 ## Migration from `eslint-plugin-markdown`
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ export default defineConfig([
 | ------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [`markdown`](./docs/processors/markdown.md) | Extract fenced code blocks from the Markdown code so they can be linted separately. |
 
-**Important:** You cannot lint a file's Markdown content and its fenced code blocks in the same run. When the `markdown` processor is applied to a file, only the extracted code blocks are linted — any Markdown rules (such as `markdown/heading-increment`) configured for that file are silently ignored. This is an ESLint limitation, not something this plugin can work around. See [Workarounds](./docs/processors/markdown.md#workarounds) for ways to lint both.
+**Important:** You cannot lint a file's Markdown content and its fenced code blocks in a single ESLint run. When the `markdown` processor is applied to a file, only the extracted code blocks are linted; any Markdown-specific rules configured for the original file, such as `markdown/heading-increment`, are silently ignored. This is a current limitation of ESLint processors. See [Workarounds](./docs/processors/markdown.md#workarounds) for ways to lint both.
 
 ## Migration from `eslint-plugin-markdown`
 

--- a/docs/processors/markdown.md
+++ b/docs/processors/markdown.md
@@ -38,7 +38,7 @@ This is plain text and doesn't get linted.
 
 Unless a fenced code block's syntax appears as a file extension in file patterns in your config file, it will be ignored.
 
-**Important:** You cannot combine this processor and Markdown-specific linting rules. You can either lint the code blocks or lint the Markdown, but not both. This is an ESLint limitation.
+**Important:** You cannot combine this processor and Markdown-specific linting rules. When the processor is applied to a file, ESLint lints only the code blocks that the processor extracts — the Markdown content itself is not linted, and any Markdown rules configured for the file are silently ignored without an error or warning. This is an ESLint limitation. See [Workarounds](#workarounds) for ways to lint both.
 
 ## Basic Configuration
 
@@ -238,3 +238,18 @@ highlighting. Skip the block to prevent warnings about invalid syntax.
 console.log("This code block is linted normally.");
 ```
 ````
+
+## Workarounds
+
+You can't lint both in a single run, but there's more than one way to get full coverage anyway:
+
+- **Run two configs.** Keep your existing config with the `markdown` processor for code blocks, and add a second config with the Markdown language and rules for content. Then run ESLint twice:
+
+  ```sh
+  eslint .                              # lints fenced code blocks
+  eslint -c eslint.config-content.js .  # lints Markdown content
+  ```
+
+  This works well in CI and git hooks. The catch is that most editor integrations only load the default config file, so you won't see the content-linting results while you type. (This repository takes exactly this approach.)
+
+- **Hand content-linting off to another tool.** Keep the `markdown` processor for code blocks, and let a dedicated tool such as [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) handle the Markdown content instead. It ships with editor extensions, so either way you still get real-time feedback.

--- a/docs/processors/markdown.md
+++ b/docs/processors/markdown.md
@@ -38,7 +38,7 @@ This is plain text and doesn't get linted.
 
 Unless a fenced code block's syntax appears as a file extension in file patterns in your config file, it will be ignored.
 
-**Important:** You cannot combine this processor and Markdown-specific linting rules in a single ESLint run. When the processor is applied to a file, ESLint lints only the code blocks that the processor extracts; any Markdown-specific rules configured for the original file are silently ignored. This is a current limitation of ESLint processors. See [Workarounds](#workarounds) for ways to lint both.
+**Important:** You cannot combine this processor with Markdown-specific linting rules in a single ESLint run. When the processor is applied, ESLint only lints the code blocks it extracts. This is a current limitation of ESLint processors. See [Linting Markdown Content and Code Blocks](#linting-markdown-content-and-code-blocks) for a way to lint both.
 
 ## Basic Configuration
 
@@ -239,17 +239,15 @@ console.log("This code block is linted normally.");
 ```
 ````
 
-## Workarounds
+## Linting Markdown Content and Code Blocks
 
-You can't lint both in a single ESLint run, but you can use one of the following approaches:
+To lint Markdown content and fenced code blocks, use two configuration files: `eslint.config.js` with the [`processor` configuration](#basic-configuration) for fenced code blocks and `eslint.config-content.js` with the [`recommended` configuration](../../README.md#configurations) for Markdown content.
 
-- **Run ESLint with two configuration files.** Keep your existing configuration with the `markdown` processor for code blocks, and add a second configuration with the Markdown language and rules for content. Then run ESLint twice:
+Run ESLint once with each configuration:
 
-  ```sh
-  eslint .                              # lints fenced code blocks
-  eslint -c eslint.config-content.js .  # lints Markdown content
-  ```
+```sh
+eslint .                              # lints fenced code blocks
+eslint -c eslint.config-content.js .  # lints Markdown content
+```
 
-  This works well in CI and git hooks. However, most editor integrations use only one ESLint configuration at a time, so Markdown content errors may not appear in the editor. This repository uses this approach in its lint scripts and git hooks.
-
-- **Use a separate Markdown linter.** Keep the `markdown` processor for code blocks, and use a dedicated tool such as [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) to lint the Markdown content. An editor extension such as [`vscode-markdownlint`](https://github.com/DavidAnson/vscode-markdownlint) can provide real-time feedback while you type. The tradeoff is having another tool and configuration to maintain.
+This approach works well in CI and git hooks. Editor integrations may run only the default configuration, so they might not report Markdown content errors from `eslint.config-content.js` while you type. This repository uses the same two-configuration setup in its lint scripts and git hooks.

--- a/docs/processors/markdown.md
+++ b/docs/processors/markdown.md
@@ -38,7 +38,7 @@ This is plain text and doesn't get linted.
 
 Unless a fenced code block's syntax appears as a file extension in file patterns in your config file, it will be ignored.
 
-**Important:** You cannot combine this processor and Markdown-specific linting rules. When the processor is applied to a file, ESLint lints only the code blocks that the processor extracts — the Markdown content itself is not linted, and any Markdown rules configured for the file are silently ignored without an error or warning. This is an ESLint limitation. See [Workarounds](#workarounds) for ways to lint both.
+**Important:** You cannot combine this processor and Markdown-specific linting rules in a single ESLint run. When the processor is applied to a file, ESLint lints only the code blocks that the processor extracts; any Markdown-specific rules configured for the original file are silently ignored. This is a current limitation of ESLint processors. See [Workarounds](#workarounds) for ways to lint both.
 
 ## Basic Configuration
 
@@ -241,15 +241,15 @@ console.log("This code block is linted normally.");
 
 ## Workarounds
 
-You can't lint both in a single run, but there's more than one way to get full coverage anyway:
+You can't lint both in a single ESLint run, but you can use one of the following approaches:
 
-- **Run two configs.** Keep your existing config with the `markdown` processor for code blocks, and add a second config with the Markdown language and rules for content. Then run ESLint twice:
+- **Run ESLint with two configuration files.** Keep your existing configuration with the `markdown` processor for code blocks, and add a second configuration with the Markdown language and rules for content. Then run ESLint twice:
 
   ```sh
   eslint .                              # lints fenced code blocks
   eslint -c eslint.config-content.js .  # lints Markdown content
   ```
 
-  This works well in CI and git hooks. The catch is that most editor integrations only load the default config file, so you won't see the content-linting results while you type. (This repository takes exactly this approach.)
+  This works well in CI and git hooks. However, most editor integrations use only one ESLint configuration at a time, so Markdown content errors may not appear in the editor. This repository uses this approach in its lint scripts and git hooks.
 
-- **Hand content-linting off to another tool.** Keep the `markdown` processor for code blocks, and let a dedicated tool such as [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) handle the Markdown content instead. It ships with editor extensions, so either way you still get real-time feedback.
+- **Use a separate Markdown linter.** Keep the `markdown` processor for code blocks, and use a dedicated tool such as [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) to lint the Markdown content. An editor extension such as [`vscode-markdownlint`](https://github.com/DavidAnson/vscode-markdownlint) can provide real-time feedback while you type. The tradeoff is having another tool and configuration to maintain.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

@eslint/markdown's markdown processor cannot lint a file's Markdown content and its fenced code blocks in a single ESLint run. When the processor is applied, ESLint lints only the extracted code blocks, so Markdown-specific rules configured for the original file do not run.

This limitation was only mentioned briefly in docs/processors/markdown.md and was easy to miss, leading to repeated confusion in #276, #560, #297, and #695.

#### What changes did you make? (Give an overview)

- Added a brief warning about this limitation to the root `README.md`, immediately after the Processors table, with a link to the processor documentation.
- Expanded the existing `**Important:**` note in `docs/processors/markdown.md` to clarify that only the extracted code blocks are linted and that Markdown-specific rules configured for the original file are silently ignored.
- Added a new "Workarounds" section to `docs/processors/markdown.md` describing two approaches: running ESLint twice with separate configuration files, or using a dedicated Markdown linter such as `markdownlint-cli2` alongside the processor.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
fixes #695

#### Is there anything you'd like reviewers to focus on?

Whether the wording and placement of the new "Workarounds" section—at the end of docs/processors/markdown.md and linked from both the README and the processor documentation's Important note—match what was discussed in #695, and whether the two listed workarounds are the approaches you would recommend to users.