### PR TITLE
fix: add `mdast` type augmentation for TOML and JSON nodes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,21 @@ export interface Json extends Literal {
  */
 export interface JsonData extends Data {}
 
+/**
+ * Registers additional mdast nodes as valid front matter and root content.
+ */
+declare module "mdast" {
+	interface FrontmatterContentMap {
+		toml: Toml;
+		json: Json;
+	}
+
+	interface RootContentMap {
+		toml: Toml;
+		json: Json;
+	}
+}
+
 //------------------------------------------------------------------------------
 // Exports: Language and Source Code
 //------------------------------------------------------------------------------

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -47,6 +47,15 @@ import type {
 	TableRow,
 	// Extensions (front matter)
 	Yaml,
+	// Contents
+	BlockContent,
+	BlockContentMap,
+	FrontmatterContent,
+	FrontmatterContentMap,
+	PhrasingContent,
+	PhrasingContentMap,
+	RootContent,
+	RootContentMap,
 } from "mdast";
 import type { InlineMath, Math } from "mdast-util-math";
 
@@ -144,6 +153,30 @@ typeof processorPlugins satisfies {};
 		end: { line: 1, column: 1, offset: 0 },
 	};
 }
+
+// Check that `Toml` is registered as mdast front matter and root content.
+({}) as Toml satisfies FrontmatterContent;
+({}) as Toml satisfies FrontmatterContentMap["toml"];
+({}) as Toml satisfies RootContent;
+({}) as Toml satisfies RootContentMap["toml"];
+
+// Check that `Json` is registered as mdast front matter and root content.
+({}) as Json satisfies FrontmatterContent;
+({}) as Json satisfies FrontmatterContentMap["json"];
+({}) as Json satisfies RootContent;
+({}) as Json satisfies RootContentMap["json"];
+
+// Check that `InlineMath` is registered as mdast phrasing and root content.
+({}) as InlineMath satisfies PhrasingContent;
+({}) as InlineMath satisfies PhrasingContentMap["inlineMath"];
+({}) as InlineMath satisfies RootContent;
+({}) as InlineMath satisfies RootContentMap["inlineMath"];
+
+// Check that `Math` is registered as mdast block and root content.
+({}) as Math satisfies BlockContent;
+({}) as Math satisfies BlockContentMap["math"];
+({}) as Math satisfies RootContent;
+({}) as Math satisfies RootContentMap["math"];
 
 const validLanguageOptions1: MarkdownLanguageOptions = {
 	frontmatter: false,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

I expected the `Toml` and `Json` node types to be present in `FrontmatterContentMap` and `RootContentMap` from [`mdast`](https://github.com/syntax-tree/mdast), but they aren’t.

This prevents users from accessing the `Toml` and `Json` node types when using the `FrontmatterContent` or `RootContent` types, which are typically accessed through `node.children` when finding child nodes or directly via `@types/mdast`.

### What did you expect to happen?

I expected the `Toml` and `Json` node types to be present in `FrontmatterContentMap` and `RootContentMap` from [`mdast`](https://github.com/syntax-tree/mdast), but they aren’t.

### What actually happened?

It produces type errors when accessing the `Toml` and `Json` types, as shown below:

```ts
import type { FrontmatterContent } from "mdast";

({}) as Toml satisfies FrontmatterContent;

({}) as Json satisfies FrontmatterContent;
```

### Link to Minimal Reproducible Example

Pasting the following code into `tests/types/types.test.ts` produces TypeScript type errors:

```ts
import type {
	FrontmatterContent,
	FrontmatterContentMap,
	RootContent,
	RootContentMap,
} from "mdast";

// Check that `Toml` is registered as mdast front matter and root content.
({}) as Toml satisfies FrontmatterContent;
({}) as Toml satisfies FrontmatterContentMap["toml"];
({}) as Toml satisfies RootContent;
({}) as Toml satisfies RootContentMap["toml"];

// Check that `Json` is registered as mdast front matter and root content.
({}) as Json satisfies FrontmatterContent;
({}) as Json satisfies FrontmatterContentMap["json"];
({}) as Json satisfies RootContent;
({}) as Json satisfies RootContentMap["json"];
```

## What changes did you make? (Give an overview)

This change adds `mdast` type augmentation and type tests for TOML and JSON nodes, which is a common pattern in the `mdast` type system. This allows us to define custom nodes and extend the `mdast` typings.

For example, `mdast-util-math`, which is used as a dependency in our project, also declares the following type augmentation so that users can access the extended types directly from the `mdast` typings:

https://github.com/syntax-tree/mdast-util-math/blob/main/index.d.ts#L93-L107

```ts
// Add nodes to tree.
declare module 'mdast' {
  interface BlockContentMap {
    math: Math
  }


  interface PhrasingContentMap {
    inlineMath: InlineMath
  }


  interface RootContentMap {
    inlineMath: InlineMath
    math: Math
  }
}
```

The JSDoc in `mdast` also mentions that this can be augmented when custom node types are used:

<img width="1016" height="486" alt="image" src="https://github.com/user-attachments/assets/861da595-2fb9-4572-93d2-079add1a5e3b" />

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I identified this problem while working on Rust parser integration and my custom plugins.