### PR TITLE
docs: describe default values for `frontmatter` and `math` options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -139,11 +139,13 @@ declare module "mdast" {
 export interface MarkdownLanguageOptions extends LanguageOptions {
 	/**
 	 * The options for parsing frontmatter.
+	 * @default false
 	 */
 	frontmatter?: false | "yaml" | "toml" | "json";
 
 	/**
 	 * The options for parsing math.
+	 * @default false
 	 */
 	math?: boolean;
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

A small JSDoc documentation update to describe the default values for the `frontmatter` and `math` options.

This PR was split off from https://github.com/eslint/markdown/pull/706 to avoid adding unnecessary diffs to it.

#### What changes did you make? (Give an overview)

A small JSDoc documentation update to describe the default values for the `frontmatter` and `math` options.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A