### PR TITLE
fix: support unquoted aria-hidden value in require-alt-text

### DIFF
--- a/src/rules/require-alt-text.js
+++ b/src/rules/require-alt-text.js
@@ -26,6 +26,8 @@ import { stripHtmlComments } from "../util.js";
 //-----------------------------------------------------------------------------
 
 const imgTagPattern = /<img(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?\/?>/giu;
+const ariaHiddenTruePattern =
+	/\saria-hidden\s*=\s*(?:"true"|'true'|true)(?=\s|\/?>)/iu;
 
 /**
  * Creates a regex to match HTML attributes
@@ -78,14 +80,8 @@ export default /** @satisfies {RequireAltTextRuleDefinition} */ ({
 
 				while ((match = imgTagPattern.exec(text)) !== null) {
 					const imgTag = match[0];
-					const ariaHiddenMatch = imgTag.match(
-						getHtmlAttributeRe("aria-hidden"),
-					);
-					if (
-						ariaHiddenMatch &&
-						ariaHiddenMatch[1] &&
-						ariaHiddenMatch[1].toLowerCase() === "true"
-					) {
+
+					if (ariaHiddenTruePattern.test(imgTag)) {
 						continue;
 					}
 

--- a/src/rules/require-alt-text.js
+++ b/src/rules/require-alt-text.js
@@ -27,7 +27,7 @@ import { stripHtmlComments } from "../util.js";
 
 const imgTagPattern = /<img(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?\/?>/giu;
 const ariaHiddenTruePattern =
-	/\saria-hidden\s*=\s*(?:"true"|'true'|true)(?=\s|\/?>)/iu;
+	/[\s"']aria-hidden\s*=\s*(?:"true"|'true'|true(?=\s|\/?>))/iu;
 
 /**
  * Creates a regex to match HTML attributes

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -68,6 +68,8 @@ ruleTester.run("require-alt-text", rule, {
 		'<img src="image.png" aria-hidden=true/>',
 		'<img src="image.png" aria-hidden = true/>',
 		'<img src="image.png" ARIA-HIDDEN=TRUE />',
+		'<img before="true"aria-hidden="true"after="true">',
+		"<img before='true'aria-hidden='true'after='true'>",
 
 		'<p><img src="image.png" alt="Descriptive text" /></p>',
 		'<!-- <img src="image.png" /> -->',

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -402,14 +402,14 @@ ruleTester.run("require-alt-text", rule, {
 			],
 		},
 		{
-			code: '<img src="image.png" aria-hidden=falsefoo/>',
+			code: '<img src="image.png" aria-hidden=truefoo/>',
 			errors: [
 				{
 					messageId: "altTextRequired",
 					line: 1,
 					column: 1,
 					endLine: 1,
-					endColumn: 44,
+					endColumn: 43,
 				},
 			],
 		},

--- a/tests/rules/require-alt-text.test.js
+++ b/tests/rules/require-alt-text.test.js
@@ -63,6 +63,12 @@ ruleTester.run("require-alt-text", rule, {
 		'<img src="image.png" aria-hidden alt="alt">',
 		'<img src="image.png" aria-hidden="true"/>',
 		'<img src="image.png" ARIA-HIDDEN="TRUE" />',
+
+		// Unquoted aria-hidden values
+		'<img src="image.png" aria-hidden=true/>',
+		'<img src="image.png" aria-hidden = true/>',
+		'<img src="image.png" ARIA-HIDDEN=TRUE />',
+
 		'<p><img src="image.png" alt="Descriptive text" /></p>',
 		'<!-- <img src="image.png" /> -->',
 		'Some text <!-- <img src="image.png" /> --> more text.',
@@ -380,6 +386,30 @@ ruleTester.run("require-alt-text", rule, {
 					column: 1,
 					endLine: 1,
 					endColumn: 43,
+				},
+			],
+		},
+		{
+			code: '<img src="image.png" aria-hidden=false/>',
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 41,
+				},
+			],
+		},
+		{
+			code: '<img src="image.png" aria-hidden=falsefoo/>',
+			errors: [
+				{
+					messageId: "altTextRequired",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 44,
 				},
 			],
 		},


### PR DESCRIPTION
> Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
This PR updates require-alt-text to recognize an unquoted aria-hidden=true attribute.

HTML permits attribute values to be written without quotes, but the existing implementation handles the following forms differently:
```html
<img src="quoted.png" aria-hidden="true" />
<img src="unquoted.png" aria-hidden=true />
```
Since both forms set the value of aria-hidden to true, this PR updates the rule to skip the alternative text check in both cases.

#### What changes did you make? (Give an overview)
- Added a dedicated regular expression that recognizes double-quoted, single-quoted, and unquoted `aria-hidden=true` attributes.
- Added support for optional whitespace around the equals sign.
- Made matching case-insensitive for both the attribute name and value.
- Added a boundary check to ensure that the alternative text check is skipped only when the value is exactly true.
- Added valid test cases for the following unquoted forms:
   - `aria-hidden=true`
   - `aria-hidden = true`
   - `ARIA-HIDDEN=TRUE`
- Added invalid test cases to verify that `aria-hidden=false` and `aria-hidden=truefoo` are still reported.

The regex test cases for this change are available on [RegExr](https://regexr.com/8o80k).

#### Related Issues

fixes #718

#### Is there anything you'd like reviewers to focus on?

To keep the scope of this change minimal, the implementation adds a dedicated regular expression for detecting `aria-hidden=true` instead of extending `getHtmlAttributeRe()`.

There are two reasons for this approach:

1. It avoids affecting the existing `alt` attribute parsing behavior and avoids recreating the `aria-hidden` regular expression each time an image tag is processed.
2. `aria-hidden` requires checking whether its value is exactly `true`, while `getHtmlAttributeRe("alt")` captures the value of the `alt` attribute to determine whether it consists only of whitespace. I considered these attributes to have different validation purposes and criteria.

I would appreciate feedback on whether this dedicated regular expression is appropriate or whether it would be better to generalize `getHtmlAttributeRe()` to handle both quoted and unquoted attribute values. :)
