### PR TITLE
fix: correct www autofix in `no-bare-urls`

### DIFF
--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -169,7 +169,7 @@ export default /** @satisfies {NoBareUrlsRuleDefinition} */ ({
 							messageId: "bareUrl",
 							fix(fixer) {
 								let replacementText = `<${text}>`;
-
+								// GFM parses `www` autolinks with an `http://` URL.
 								if (url === `http://${text}`) {
 									replacementText = `[${text}](${url})`;
 								}

--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -168,15 +168,15 @@ export default /** @satisfies {NoBareUrlsRuleDefinition} */ ({
 							node: linkNode,
 							messageId: "bareUrl",
 							fix(fixer) {
-								let replacementUrl = `<${text}>`;
+								let replacementText = `<${text}>`;
 
 								if (url === `http://${text}`) {
-									replacementUrl = `[${text}](${url})`;
+									replacementText = `[${text}](${url})`;
 								}
 
 								return fixer.replaceText(
 									linkNode,
-									replacementUrl,
+									replacementText,
 								);
 							},
 						});

--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -168,7 +168,16 @@ export default /** @satisfies {NoBareUrlsRuleDefinition} */ ({
 							node: linkNode,
 							messageId: "bareUrl",
 							fix(fixer) {
-								return fixer.replaceText(linkNode, `<${text}>`);
+								let replacementUrl = `<${text}>`;
+
+								if (url === `http://${text}`) {
+									replacementUrl = `[${text}](${url})`;
+								}
+
+								return fixer.replaceText(
+									linkNode,
+									replacementUrl,
+								);
 							},
 						});
 					}

--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -171,12 +171,16 @@ export default /** @satisfies {NoBareUrlsRuleDefinition} */ ({
 								let replacementText = `<${text}>`;
 								// GFM parses `www` autolinks with an `http://` URL.
 								if (url === `http://${text}`) {
+									const escapedLinkText = text.replace(
+										/[[\]\\*_~`]/gu,
+										"\\$&",
+									);
 									const escapedLinkDestination = url.replace(
 										/[\\()]/gu,
 										"\\$&",
 									);
 
-									replacementText = `[${text}](${escapedLinkDestination})`;
+									replacementText = `[${escapedLinkText}](${escapedLinkDestination})`;
 								}
 
 								return fixer.replaceText(

--- a/src/rules/no-bare-urls.js
+++ b/src/rules/no-bare-urls.js
@@ -171,7 +171,12 @@ export default /** @satisfies {NoBareUrlsRuleDefinition} */ ({
 								let replacementText = `<${text}>`;
 								// GFM parses `www` autolinks with an `http://` URL.
 								if (url === `http://${text}`) {
-									replacementText = `[${text}](${url})`;
+									const escapedLinkDestination = url.replace(
+										/[\\()]/gu,
+										"\\$&",
+									);
+
+									replacementText = `[${text}](${escapedLinkDestination})`;
 								}
 
 								return fixer.replaceText(

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -126,6 +126,19 @@ ruleTester.run("no-bare-urls", rule, {
 			],
 		},
 		{
+			code: "www.example.com/a[b",
+			output: "[www.example.com/a\\[b](http://www.example.com/a[b)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
+		{
 			code: "www.example.com/a*b*c",
 			output: "[www.example.com/a\\*b\\*c](http://www.example.com/a*b*c)",
 			errors: [
@@ -141,6 +154,19 @@ ruleTester.run("no-bare-urls", rule, {
 		{
 			code: "www.example.com/a~b~c",
 			output: "[www.example.com/a\\~b\\~c](http://www.example.com/a~b~c)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "www.example.com/a`b`c",
+			output: "[www.example.com/a\\`b\\`c](http://www.example.com/a`b`c)",
 			errors: [
 				{
 					messageId: "bareUrl",

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -74,6 +74,19 @@ ruleTester.run("no-bare-urls", rule, {
 	],
 	invalid: [
 		{
+			code: "Visit www.example.com for details.",
+			output: "Visit [www.example.com](http://www.example.com) for details.",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
 			code: "https://www.example.com/",
 			output: "<https://www.example.com/>",
 			errors: [

--- a/tests/rules/no-bare-urls.test.js
+++ b/tests/rules/no-bare-urls.test.js
@@ -87,6 +87,71 @@ ruleTester.run("no-bare-urls", rule, {
 			],
 		},
 		{
+			code: "www.google.com/search?q=(business))+ok",
+			output: "[www.google.com/search?q=(business))+ok](http://www.google.com/search?q=\\(business\\)\\)+ok)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 39,
+				},
+			],
+		},
+		{
+			code: "www.example.com/a\\*b",
+			output: "[www.example.com/a\\\\\\*b](http://www.example.com/a\\\\*b)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: "www.example.com/a]b",
+			output: "[www.example.com/a\\]b](http://www.example.com/a]b)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: "www.example.com/a*b*c",
+			output: "[www.example.com/a\\*b\\*c](http://www.example.com/a*b*c)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "www.example.com/a~b~c",
+			output: "[www.example.com/a\\~b\\~c](http://www.example.com/a~b~c)",
+			errors: [
+				{
+					messageId: "bareUrl",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
 			code: "https://www.example.com/",
 			output: "<https://www.example.com/>",
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fix the incorrect autofix for `www` autolinks.

#### What changes did you make? (Give an overview)

Updated `no-bare-urls` to convert `www.example.com` into `[www.example.com](http://www.example.com)`.
Added a test for the autofix result.

#### Related Issues

Fixes #710

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Nothing in particular.


Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic formatting for bare URLs containing Markdown-special characters.
  - Preserves link text and destinations by escaping characters such as parentheses, brackets, backslashes, backticks, and table pipes.
  - Correctly formats affected `www.` links as Markdown links instead of angle-bracket autolinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->