### PR TITLE
chore: fix ignore patterns in `eslint.config-content.js`

### DIFF
--- a/eslint.config-content.js
+++ b/eslint.config-content.js
@@ -3,7 +3,7 @@ import markdown from "./src/index.js";
 
 export default defineConfig([
 	globalIgnores(
-		["**/*.js", "**/.cjs", "**/.mjs", "tests/fixtures/"],
+		["**/*.js", "**/*.cjs", "**/*.mjs", "tests/fixtures/"],
 		"markdown/content/ignores",
 	),
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fixes ignore patterns in `eslint.config-content.js`. The lint run that uses this config is currently mistakenly linting `examples/react/eslint.config.mjs` and `examples/typescript/eslint.config.mjs` in addition to markdown files.

#### What changes did you make? (Give an overview)

Updated the patterns for .cjs and .mjs files.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
