### PR TITLE
fix: handle `symbol` in `validateLanguageOptions`

### DIFF
--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -185,7 +185,7 @@ export class MarkdownLanguage {
 			!validFrontmatterOptions.has(frontmatterOption)
 		) {
 			throw new Error(
-				`Invalid language option value \`${frontmatterOption}\` for frontmatter. Expected one of \`false\`, \`"yaml"\`, \`"toml"\`, or \`"json"\`.`,
+				`Invalid language option value \`${String(frontmatterOption)}\` for frontmatter. Expected one of \`false\`, \`"yaml"\`, \`"toml"\`, or \`"json"\`.`,
 			);
 		}
 
@@ -194,7 +194,7 @@ export class MarkdownLanguage {
 
 		if (mathOption !== undefined && typeof mathOption !== "boolean") {
 			throw new Error(
-				`Invalid language option value \`${mathOption}\` for math. Expected a boolean.`,
+				`Invalid language option value \`${String(mathOption)}\` for math. Expected a boolean.`,
 			);
 		}
 	}

--- a/tests/language/markdown-language.test.js
+++ b/tests/language/markdown-language.test.js
@@ -58,6 +58,17 @@ describe("MarkdownLanguage", () => {
 						'Invalid language option value `123` for frontmatter. Expected one of `false`, `"yaml"`, `"toml"`, or `"json"`.',
 				},
 			);
+			assert.throws(
+				() => {
+					language.validateLanguageOptions({
+						frontmatter: Symbol("frontmatter"),
+					});
+				},
+				{
+					message:
+						'Invalid language option value `Symbol(frontmatter)` for frontmatter. Expected one of `false`, `"yaml"`, `"toml"`, or `"json"`.',
+				},
+			);
 		});
 
 		it("should not throw an error when `frontmatter` has a correct value in commonmark mode", () => {
@@ -114,6 +125,17 @@ describe("MarkdownLanguage", () => {
 				{
 					message:
 						"Invalid language option value `123` for math. Expected a boolean.",
+				},
+			);
+			assert.throws(
+				() => {
+					language.validateLanguageOptions({
+						math: Symbol("math"),
+					});
+				},
+				{
+					message:
+						"Invalid language option value `Symbol(math)` for math. Expected a boolean.",
 				},
 			);
 		});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

### Which language are you using?

CommonMark and GFM.

### What did you do?

When I use `MarkdownLanguage#validateLanguageOptions` with a `symbol` value, it produces an incorrect error message.

### What did you expect to happen?

I expected the error message to be:

```sh
Invalid language option value `Symbol(frontmatter)` for frontmatter. Expected one of `false`, `"yaml"`, `"toml"`, or `"json"`.
```

### What actually happened?

However, I got:

```sh
'Cannot convert a Symbol value to a string'
```

### Link to Minimal Reproducible Example

Create a `test.js` file in the root of the `markdown` project.

```js
import { MarkdownLanguage } from "./src/language/markdown-language.js";

const language = new MarkdownLanguage();

for (const languageOptions of [
	{ frontmatter: Symbol("frontmatter") },
	{ math: Symbol("math") },
]) {
	try {
		language.validateLanguageOptions(languageOptions);
	} catch (error) {
		console.error(error.message);
	}
}
```

## What changes did you make? (Give an overview)

This is a simple bug fix. I’ve coerced the message variable with `String` so that it can also handle an incorrectly passed `symbol` value.

This is a subtle edge case, but I noticed it while working on #706.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I’ve verified that the JSON and CSS language plugins don’t have this type of issue.