### PR TITLE
chore: specify type arguments for `MarkdownLanguage`

### DIFF
--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -24,7 +24,7 @@ import { math } from "micromark-extension-math";
 
 /**
  * @import { Language, File, ParseResult, OkParseResult } from "@eslint/core";
- * @import { Root, Node } from "mdast";
+ * @import { Node, Root } from "mdast";
  * @import { Options } from "mdast-util-from-markdown";
  * @import { MarkdownLanguageOptions, MarkdownLanguageContext } from "../types.js";
  * @typedef {Options['extensions']} Extensions

--- a/src/language/markdown-language.js
+++ b/src/language/markdown-language.js
@@ -24,7 +24,7 @@ import { math } from "micromark-extension-math";
 
 /**
  * @import { Language, File, ParseResult, OkParseResult } from "@eslint/core";
- * @import { Root } from "mdast";
+ * @import { Root, Node } from "mdast";
  * @import { Options } from "mdast-util-from-markdown";
  * @import { MarkdownLanguageOptions, MarkdownLanguageContext } from "../types.js";
  * @typedef {Options['extensions']} Extensions
@@ -111,7 +111,7 @@ function createParserOptions(mode, languageOptions) {
 
 /**
  * Markdown Language Object
- * @implements {Language}
+ * @implements {Language<{ LangOptions: MarkdownLanguageOptions; Code: MarkdownSourceCode; RootNode: Root; Node: Node }>}
  */
 export class MarkdownLanguage {
 	/**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

While the JSON and CSS languages specify concrete type arguments for the `Language` interface, Markdown did not. This left its implementation loosely typed, so this change tightens the type checking.

- https://github.com/eslint/css/blob/main/src/languages/css-language.js#L100
- https://github.com/eslint/json/blob/main/src/languages/json-language.js#L33

#### What changes did you make? (Give an overview)

Specify the concrete language options, source code, root node, and node types for `MarkdownLanguage`'s `Language` implementation.

This aligns `MarkdownLanguage` with the JSON and CSS language implementations and provides stricter type checking for future changes.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
