### PR TITLE
fix: handle empty ATX headings in `no-missing-atx-heading-space`

### DIFF
--- a/src/rules/no-missing-atx-heading-space.js
+++ b/src/rules/no-missing-atx-heading-space.js
@@ -75,7 +75,7 @@ export default /** @satisfies {NoMissingAtxHeadingSpaceRuleDefinition} */ ({
 				const text = sourceCode.getText(node);
 				const match = trailingAtxHeadingHashPattern.exec(text);
 
-				if (match === null) {
+				if (match === null || match.index === 0) {
 					return;
 				}
 

--- a/tests/rules/no-missing-atx-heading-space.test.js
+++ b/tests/rules/no-missing-atx-heading-space.test.js
@@ -235,6 +235,24 @@ const validHeadings = [
 		code: `# Backslash Escaping${"\\".repeat(7)}#`,
 		options: [{ checkClosedHeadings: true }],
 	},
+
+	// 15. Empty heading
+	{
+		code: "#",
+		options: [{ checkClosedHeadings: true }],
+	},
+	{
+		code: "##",
+		options: [{ checkClosedHeadings: true }],
+	},
+	{
+		code: "###",
+		options: [{ checkClosedHeadings: true }],
+	},
+	{
+		code: "# #",
+		options: [{ checkClosedHeadings: true }],
+	},
 ];
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

### What did you do?

Enabled `markdown/no-missing-atx-heading-space` with `checkClosedHeadings: true` and linted an empty ATX heading:

[Playground](https://explorer.eslint.org/#eslint-explorer=v2.eyJzdGF0ZSI6eyJ0b29sIjoiYXN0IiwiY29kZSI6eyJqYXZhc2NyaXB0IjoiIiwianNvbiI6IiIsIm1hcmtkb3duIjoiIyIsImNzcyI6IkBrZXlmcmFtZXMgdGVzdCB7XG5cdDAlIHtcblx0XHRvcGFjaXR5OiAwO1xuXHR9XG5cbiAgICBmcm9tIHtcblx0XHRvcGFjaXR5OiAwO1xuICAgIH1cblxuXHQxMDAlIHtcblx0XHRvcGFjaXR5OiAxO1xuXHR9XG59IiwiaHRtbCI6IjwhRE9DVFlQRSBodG1sPlxuPCEtLVxuVHlwZSBvciBwYXN0ZSBzb21lIEhUTUwgaGVyZSB0byBsZWFybiBtb3JlIGFib3V0XG50aGUgc3RhdGljIGFuYWx5c2lzIHRoYXQgRVNMaW50IGNhbiBkbyBmb3IgeW91LlxuXG5UaGUgdGFicyBhcmU6XG5cbi0gQVNUIC0gVGhlIEFic3RyYWN0IFN5bnRheCBUcmVlIG9mIHRoZSBjb2RlLCB3aGljaCBjYW5cbmJlIHVzZWZ1bCB0byB1bmRlcnN0YW5kIHRoZSBzdHJ1Y3R1cmUgb2YgdGhlIGNvZGUuIFlvdVxuY2FuIHZpZXcgdGhpcyBzdHJ1Y3R1cmUgYXMgSlNPTiBvciBpbiBhIHRyZWUgZm9ybWF0LlxuLS0-XG5cbjxodG1sIGxhbmc9XCJlblwiPlxuICAgIDxoZWFkPlxuICAgICAgICA8bWV0YSBjaGFyc2V0PVwiVVRGLThcIj5cbiAgICAgICAgPHRpdGxlPkhUTUw8L3RpdGxlPlxuICAgIDwvaGVhZD5cbiAgICA8Ym9keT5cbiAgICAgICAgPHA-VGV4dDwvcD5cbiAgICA8L2JvZHk-XG48L2h0bWw-In0sImxhbmd1YWdlIjoibWFya2Rvd24iLCJqc09wdGlvbnMiOnsicGFyc2VyIjoiZXNwcmVlIiwic291cmNlVHlwZSI6Im1vZHVsZSIsImlzVmVyc2lvbiI6ImxhdGVzdCIsImlzSlNYIjpmYWxzZSwiZXNWZXJzaW9uIjoibGF0ZXN0In0sImpzb25PcHRpb25zIjp7Impzb25Nb2RlIjoianNvbjUiLCJhbGxvd1RyYWlsaW5nQ29tbWFzIjpmYWxzZX0sImNzc09wdGlvbnMiOnsiY3NzTW9kZSI6ImNzcyIsInRvbGVyYW50IjpmYWxzZX0sIm1hcmtkb3duT3B0aW9ucyI6eyJtYXJrZG93bk1vZGUiOiJnZm0iLCJtYXJrZG93bkZyb250bWF0dGVyIjoib2ZmIiwibWFya2Rvd25NYXRoIjpmYWxzZX0sImh0bWxPcHRpb25zIjp7InRlbXBsYXRlRW5naW5lU3ludGF4Ijoibm9uZSIsImZyb250bWF0dGVyIjoib2ZmIn0sIndyYXAiOmZhbHNlLCJ2aWV3TW9kZXMiOnsiYXN0VmlldyI6InRyZWUiLCJzY29wZVZpZXciOiJmbGF0IiwicGF0aFZpZXciOiJncmFwaCJ9LCJwYXRoSW5kZXgiOnsiaW5kZXgiOjAsImluZGV4ZXMiOjF9LCJlc3F1ZXJ5U2VsZWN0b3IiOnsic2VsZWN0b3IiOiIifX0sInZlcnNpb24iOjB9)

```md
#
```

### What did you expect to happen?

The empty ATX heading should be accepted without an error.

### What actually happened?

The opening hash was mistaken for a closing hash, causing `getLocFromIndex(-1)` to throw:

```text
RangeError: Index out of range (requested index -1, but source text has length 1).
```

## What changes did you make? (Give an overview)

Ignore trailing-hash matches at index `0` and add tests for empty ATX and empty closed ATX headings.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty ATX headings are now handled correctly when closed-heading checks are enabled.
  * Prevented false-positive validation reports for headings containing only heading markers.

* **Tests**
  * Added coverage for empty headings using one or more heading markers, including closed-heading syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->